### PR TITLE
Improved text antialiasing at small sizes

### DIFF
--- a/src/GLVisualize/assets/shader/distance_shape.frag
+++ b/src/GLVisualize/assets/shader/distance_shape.frag
@@ -13,7 +13,8 @@ struct Nothing{ //Nothing type, to encode if some variable doesn't contain any d
 #define DISTANCEFIELD     3
 #define TRIANGLE          4
 
-#define ALIASING_CONST    1.05
+// Half width of antialiasing smoothstep
+#define ANTIALIAS_RADIUS  0.8
 #define M_SQRT_2          1.4142135
 
 
@@ -33,18 +34,19 @@ flat in vec4            f_stroke_color;
 flat in vec4            f_glow_color;
 flat in uvec2           f_id;
 flat in int             f_primitive_index;
-in vec2                 f_uv;
-in vec2                 f_uv_offset;
+in vec2                 f_uv; // f_uv.{x,y} are in -1..1
+flat in vec4            f_uv_texture_bbox;
 
 
 
 float aastep(float threshold1, float value) {
-    float afwidth = length(vec2(dFdx(value), dFdy(value))) * ALIASING_CONST;
+    float afwidth = length(vec2(dFdx(value), dFdy(value))) * ANTIALIAS_RADIUS;
     return smoothstep(threshold1-afwidth, threshold1+afwidth, value);
 }
 float aastep(float threshold1, float threshold2, float value) {
-    float afwidth = length(vec2(dFdx(value), dFdy(value))) * ALIASING_CONST;
-    return smoothstep(threshold1-afwidth, threshold1+afwidth, value)-smoothstep(threshold2-afwidth, threshold2+afwidth, value);
+    float afwidth = length(vec2(dFdx(value), dFdy(value))) * ANTIALIAS_RADIUS;
+    return smoothstep(threshold1-afwidth, threshold1+afwidth, value) -
+           smoothstep(threshold2-afwidth, threshold2+afwidth, value);
 }
 
 float step2(float edge1, float edge2, float value){
@@ -110,13 +112,17 @@ float get_distancefield(Nothing distancefield, vec2 uv){
 void write2framebuffer(vec4 color, uvec2 id);
 
 void main(){
-
     float signed_distance = 0.0;
+
+    // UV coords in the texture are clamped so that they don't stray outside
+    // the valid subregion of the texture atlas containing the current glyph.
+    vec2 tex_uv = mix(f_uv_texture_bbox.xy, f_uv_texture_bbox.zw,
+                      clamp(0.5*(f_uv+1.0), 0.0, 1.0));
 
     if(shape == CIRCLE)
         signed_distance = circle(f_uv);
     else if(shape == DISTANCEFIELD)
-        signed_distance = get_distancefield(distancefield, f_uv_offset);
+        signed_distance = get_distancefield(distancefield, tex_uv);
     else if(shape == ROUNDED_RECTANGLE)
         signed_distance = rounded_rectangle(f_uv, vec2(0.2), vec2(0.8));
     else if(shape == RECTANGLE)
@@ -129,8 +135,13 @@ void main(){
     float inside = aastep(inside_start, signed_distance);
     vec4 final_color = f_bg_color;
 
-    fill(f_color, image, f_uv_offset, inside, final_color);
+    fill(f_color, image, tex_uv, inside, final_color);
     stroke(f_stroke_color, signed_distance, half_stroke, final_color);
     glow(f_glow_color, signed_distance, aastep(-f_scale.x, signed_distance), final_color);
+    // Antialising debug tool: show the background of the sprite.
+    //final_color = mix(final_color, vec4(1,0,0,1), 0.2);
+    // TODO: In 3D, we should arguably discard fragments outside the sprite
+    //if (final_color == f_bg_color)
+    //    discard;
     write2framebuffer(final_color, f_id);
 }

--- a/src/GLVisualize/assets/shader/sprites.geom
+++ b/src/GLVisualize/assets/shader/sprites.geom
@@ -4,7 +4,7 @@
 layout(points) in;
 layout(triangle_strip, max_vertices = 4) out;
 
-vec3 qmul(vec4 quat, vec3 vec){
+mat4 qmat(vec4 quat){
     float num = quat.x * 2.0;
     float num2 = quat.y * 2.0;
     float num3 = quat.z * 2.0;
@@ -17,10 +17,11 @@ vec3 qmul(vec4 quat, vec3 vec){
     float num10 = quat.w * num;
     float num11 = quat.w * num2;
     float num12 = quat.w * num3;
-    return vec3(
-        (1.0 - (num5 + num6)) * vec.x + (num7 - num12) * vec.y + (num8 + num11) * vec.z,
-        (num7 + num12) * vec.x + (1.0 - (num4 + num6)) * vec.y + (num9 - num10) * vec.z,
-        (num8 - num11) * vec.x + (num9 + num10) * vec.y + (1.0 - (num4 + num5)) * vec.z
+    return mat4(
+        (1.0 - (num5 + num6)), (num7 + num12),        (num8 - num11),        0.0,
+        (num7 - num12),        (1.0 - (num4 + num6)), (num9 + num10),        0.0,
+        (num8 + num11),        (num9 - num10),        (1.0 - (num4 + num5)), 0.0,
+        0.0,                   0.0,                   0.0,                   1.0
     );
 }
 
@@ -31,7 +32,7 @@ uniform float glow_width;
 uniform vec2 resolution;
 
 in int  g_primitive_index[];
-in vec4 g_uv_offset_width[];
+in vec4 g_uv_texture_bbox[];
 in vec4 g_color[];
 in vec4 g_stroke_color[];
 in vec4 g_glow_color[];
@@ -47,45 +48,30 @@ flat out vec4 f_bg_color;
 flat out vec4 f_stroke_color;
 flat out vec4 f_glow_color;
 flat out uvec2 f_id;
-out vec2 f_uv;
-out vec2 f_uv_offset;
+out vec2 f_uv; // f_uv.{x,y} are in -1..1
+flat out vec4 f_uv_texture_bbox;
 
 
 uniform mat4 projection, view, model;
 
 
 
-void emit_vertex(vec2 vertex, vec2 uv, vec2 uv_offset)
+void emit_vertex(vec4 vertex, vec2 uv)
 {
-    vec4 sprite_position, final_position;
-    mat4 mview = projection * view;
-    vec4 datapoint = mview * model * vec4(g_position[0], 1);
-    if(scale_primitive)
-        final_position = model * vec4(vertex, 0, 0);
-    else{
-        final_position = vec4(vertex, 0, 0);
-    }
-    if(billboard){
-        final_position = projection * final_position;
-    }else{
-        final_position = mview * vec4(
-            qmul(g_rotation[0], final_position.xyz), 0
-        );
-    }
-    gl_Position = datapoint + final_position;
-
+    gl_Position       = vertex;
     f_uv              = uv;
-    f_uv_offset       = uv_offset;
+    f_uv_texture_bbox = g_uv_texture_bbox[0];
     f_primitive_index = g_primitive_index[0];
     f_color           = g_color[0];
     f_bg_color        = vec4(g_color[0].rgb, 0);
     f_stroke_color    = g_stroke_color[0];
     f_glow_color      = g_glow_color[0];
     f_id              = g_id[0];
-
     EmitVertex();
 }
 
+// Half width of antialiasing smoothstep. NB: Should match fragment shader
+#define ANTIALIAS_RADIUS  0.8
 
 void main(void)
 {
@@ -97,17 +83,43 @@ void main(void)
     //    |___\|
     // v1*      * v2
     vec4 o_w = g_offset_width[0];
-    vec4 uv_o_w = g_uv_offset_width[0];
-    float glow_stroke = max(glow_width, 0) + max(stroke_width, 0); //we don't need negativity here
-    vec2 final_scale = o_w.zw + 2*glow_stroke;
-    vec2 scale_rel = (final_scale / o_w.zw);
-    float hfs = glow_stroke;
+
+    // Transform central point into scene
+    mat4 pview = projection * view;
+    vec4 datapoint = pview * model * vec4(g_position[0], 1);
+
+    // Compute transform for the offset vectors from the central `datapoint`
+    mat4 trans = scale_primitive ? model : mat4(1.0);
+    trans = (billboard ? projection : pview * qmat(g_rotation[0])) * trans;
+
+    // Extra buffering is required around sprites which are antialiased so that
+    // the antialias blur doesn't get cut off (see #15). This blur falls to
+    // zero at a radius of ANTIALIAS_RADIUS pixels in the viewport coordinates
+    // and we want to buffer the vertices in the *source* sprite coordinate
+    // system so that we get this amount in the output coordinates.
+    //
+    // However this is quite tricky for arbitrary sprite rotations.  For now we
+    // just do something which is a cheap-ish and works for non-rotated sprites.
+    // For rotated sprites at glancing angles it's an underestimate, but sdf
+    // based antialiasing can't work perfectly there anyway.
+    //
+    // The following transform is the model->view->proj->clip->ndc->viewport
+    // forward transformation for vectors.
+    vec2 aa_viewport_x = 0.5*resolution*(trans*vec4(1,0,0,0)).xy / datapoint.w;
+    vec2 aa_viewport_y = 0.5*resolution*(trans*vec4(0,1,0,0)).xy / datapoint.w;
+    float aa_buf = ANTIALIAS_RADIUS/max(length(aa_viewport_x), length(aa_viewport_y));
+
+    float bbox_buf = aa_buf + max(glow_width, 0) + max(stroke_width, 0);
+    // Bounding box of billboard
+    vec4 bbox = vec4(-bbox_buf + o_w.xy,
+                     o_w.xy + o_w.zw + bbox_buf);
+    vec2 scale_rel = (bbox.zw - bbox.xy) / o_w.zw;
     vec4 uv_min_max = vec4(-scale_rel, scale_rel); //minx, miny, maxx, maxy
-    vec4 vertices = vec4(-hfs + o_w.xy, o_w.xy + (o_w.zw) + glow_stroke); // use offset as origin quad (x,y,w,h)
     f_scale = vec2(stroke_width, glow_width)/o_w.zw;
-    emit_vertex(vertices.xy, uv_min_max.xw, uv_o_w.xw);
-    emit_vertex(vertices.xw, uv_min_max.xy, uv_o_w.xy);
-    emit_vertex(vertices.zy, uv_min_max.zw, uv_o_w.zw);
-    emit_vertex(vertices.zw, uv_min_max.zy, uv_o_w.zy);
+
+    emit_vertex(datapoint + trans*vec4(bbox.xy,0,0), uv_min_max.xw);
+    emit_vertex(datapoint + trans*vec4(bbox.xw,0,0), uv_min_max.xy);
+    emit_vertex(datapoint + trans*vec4(bbox.zy,0,0), uv_min_max.zw);
+    emit_vertex(datapoint + trans*vec4(bbox.zw,0,0), uv_min_max.zy);
     EndPrimitive();
 }

--- a/src/GLVisualize/assets/shader/sprites.vert
+++ b/src/GLVisualize/assets/shader/sprites.vert
@@ -102,7 +102,7 @@ out uvec2 g_id;
 out int   g_primitive_index;
 out vec3  g_position;
 out vec4  g_offset_width;
-out vec4  g_uv_offset_width;
+out vec4  g_uv_texture_bbox;
 out vec4  g_rotation;
 out vec4  g_color;
 out vec4  g_stroke_color;
@@ -120,7 +120,7 @@ void main(){
     g_offset_width.zw = _scale(scale, scale_x, scale_y, scale_z, g_primitive_index).xy;
     g_color           = _color(color, intensity, color_map, color_norm, g_primitive_index, len);
     g_rotation        = _rotation(rotation);
-    g_uv_offset_width = uv_offset_width;
+    g_uv_texture_bbox = uv_offset_width;
     g_stroke_color    = stroke_color;
     g_glow_color      = glow_color;
 

--- a/src/gl_backend.jl
+++ b/src/gl_backend.jl
@@ -21,6 +21,10 @@ function get_texture!(atlas)
                 atlas.data,
                 minfilter = :linear,
                 magfilter = :linear,
+                # TODO: Consider alternatives to using the builtin anisotropic
+                # samplers for signed distance fields; the anisotropic
+                # filtering should happen *after* the SDF thresholding, but
+                # with the builtin sampler it happens before.
                 anisotropic = 16f0,
         )
         # update the texture, whenever a new font is added to the atlas


### PR DESCRIPTION
Here I use the signed distance function directly rather than taking a numerical derivative of it to compute the antialising smooth step width. I think this is better behaved at small text sizes.

This fixes #15 and replaces the following (close #16, close #17, close #18, close #19)