### PR TITLE
Fix stroke units for sprites

### DIFF
--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -117,8 +117,6 @@ function draw_atomic(screen::GLScreen, scene::Scene, x::Union{Scatter, MeshScatt
         gl_attributes[:shading] = AbstractPlotting.to_value(get(gl_attributes, :shading, true)) 
         marker = lift_convert(:marker, pop!(gl_attributes, :marker), x)
         if isa(x, Scatter)
-            msize = pop!(gl_attributes, :stroke_width)
-            gl_attributes[:stroke_width] = lift(pixel2world, Node(scene), msize)
             gl_attributes[:billboard] = map(rot-> isa(rot, Billboard), x.attributes[:rotations])
             gl_attributes[:distancefield][] == nothing && delete!(gl_attributes, :distancefield)
             gl_attributes[:uv_offset_width][] == Vec4f0(0) && delete!(gl_attributes, :uv_offset_width)


### PR DESCRIPTION
The units of the sprite stroke were broken by the changes in #21. Oops!

Also add a fix for visual artefacts when applying large strokes to
sampled distance fields (eg unicode glyphs), by adding on an approximate
extension of the distance field.