### PR TITLE
Fix issues created by the refactoring of signed distance rendering

### DIFF
--- a/src/GLVisualize/assets/shader/distance_shape.frag
+++ b/src/GLVisualize/assets/shader/distance_shape.frag
@@ -137,7 +137,7 @@ void main(){
     else if(shape == ROUNDED_RECTANGLE)
         signed_distance = rounded_rectangle(f_uv, vec2(0.2), vec2(0.8));
     else if(shape == RECTANGLE)
-        signed_distance = rectangle(f_uv);
+        signed_distance = 1.0; // rectangle(f_uv);
     else if(shape == TRIANGLE)
         signed_distance = triangle(f_uv);
 

--- a/src/GLVisualize/assets/shader/distance_shape.frag
+++ b/src/GLVisualize/assets/shader/distance_shape.frag
@@ -152,6 +152,7 @@ void main(){
     stroke(f_stroke_color, signed_distance, -stroke_width, final_color);
     glow(f_glow_color, signed_distance, aastep(-stroke_width, signed_distance), final_color);
     // TODO: In 3D, we should arguably discard fragments outside the sprite
+    //       But note that this may interfere with object picking.
     //if (final_color == f_bg_color)
     //    discard;
     write2framebuffer(final_color, f_id);

--- a/src/GLVisualize/assets/shader/sprites.geom
+++ b/src/GLVisualize/assets/shader/sprites.geom
@@ -33,6 +33,7 @@ uniform bool scale_primitive;
 uniform bool billboard;
 uniform float stroke_width;
 uniform float glow_width;
+uniform int shape; // for RECTANGLE hack below
 uniform vec2 resolution;
 
 in int  g_primitive_index[];
@@ -154,7 +155,11 @@ void main(void)
     // Compute required amount of buffering
     float sprite_from_viewport_scale = 1.0 / viewport_from_sprite_scale;
     float bbox_buf = sprite_from_viewport_scale *
-                     (ANTIALIAS_RADIUS + max(glow_width, 0) + max(stroke_width, 0));
+                     (// Hack!! antialiasing is disabled for RECTANGLE==1 for now
+                      // because it's used for boxplots where the sprites are
+                      // long and skinny (violating assumption 1 above)
+                      (shape == 1 ? 0.0 : ANTIALIAS_RADIUS) +
+                      max(glow_width, 0) + max(stroke_width, 0));
     // Compute xy bounding box of billboard (in model space units) after
     // buffering and associated bounding box of uv coordinates.
     vec2 bbox_radius_buf = bbox_signed_radius + sign(bbox_signed_radius)*bbox_buf;

--- a/src/GLVisualize/assets/shader/sprites.geom
+++ b/src/GLVisualize/assets/shader/sprites.geom
@@ -101,11 +101,10 @@ void main(void)
     //    |  \ |
     //    |___\|
     // v1*      * v2
-    vec4 o_w = g_offset_width[0];
-
     // Centred bounding box of billboard
-    vec2 bbox_radius = 0.5*o_w.zw;
-    vec2 sprite_bbox_centre = o_w.xy + bbox_radius;
+    vec4 o_w = g_offset_width[0];
+    vec2 bbox_signed_radius = 0.5*o_w.zw; // note; components may be negative.
+    vec2 sprite_bbox_centre = o_w.xy + bbox_signed_radius;
 
     mat4 pview = projection * view;
     // Compute transform for the offset vectors from the central point
@@ -148,7 +147,7 @@ void main(void)
     //   any calculation based on them will not be a distance function.)
     // * For sampled distance fields, we need to consistently choose the *x*
     //   for the scaling in get_distancefield_scale().
-    float sprite_from_u_scale = o_w.z;
+    float sprite_from_u_scale = abs(o_w.z);
     f_viewport_from_u_scale = viewport_from_sprite_scale * sprite_from_u_scale;
     f_distancefield_scale = get_distancefield_scale(distancefield);
 
@@ -158,10 +157,10 @@ void main(void)
                      (ANTIALIAS_RADIUS + max(glow_width, 0) + max(stroke_width, 0));
     // Compute xy bounding box of billboard (in model space units) after
     // buffering and associated bounding box of uv coordinates.
-    vec2 bbox_radius_buf = bbox_radius + bbox_buf;
+    vec2 bbox_radius_buf = bbox_signed_radius + sign(bbox_signed_radius)*bbox_buf;
     vec4 bbox = vec4(-bbox_radius_buf, bbox_radius_buf);
     // uv bounding box is the buffered version of the domain [0,1]x[0,1]
-    vec2 uv_radius = 0.5 * bbox_radius_buf / bbox_radius;
+    vec2 uv_radius = 0.5 * bbox_radius_buf / bbox_signed_radius;
     vec2 uv_center = vec2(0.5);
     vec4 uv_bbox = vec4(uv_center-uv_radius, uv_center+uv_radius); //minx, miny, maxx, maxy
 


### PR DESCRIPTION
I think this fixes the issues with negative width sprites and works around the artifacts in `barplot` created by the recent signed distance refactoring. I'm hoping these will be all that's need to unblock a release while I figure out how to do some kind of correct anisotropic filtering-like thing for signed distance fields.

I haven't done a complete test run yet as the latest GLMakie tests don't work with the released version of MakieGallery (or something along those lines; I haven't had time to investigate further). Hopefully gitlab CI will run for this PR!