### PR TITLE
fix deletion of plot objects that consist of multiple other plots

### DIFF
--- a/src/screen.jl
+++ b/src/screen.jl
@@ -62,10 +62,21 @@ function insertplots!(screen::GLScreen, scene::Scene)
 end
 
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
-    renderobject = get(screen.cache, objectid(plot)) do
-        error("Could not find $(typeof(plot)) in current GLMakie screen!")
+
+    function filterrecursively!(plotobj)
+        if !isempty(plotobj.plots)
+            # an AbstractPlot can have children, and only lowest-level children
+            # are saved in the renderlist, so we go down recursively until there
+            # are no more children to a plot object
+            filterrecursively!.(plotobj.plots)
+        else
+            renderobject = get(screen.cache, objectid(plotobj)) do
+                error("Could not find $(typeof(subplot)) in current GLMakie screen!")
+            end
+            filter!(x-> x[3] !== renderobject, screen.renderlist)
+        end
     end
-    filter!(x-> x[3] !== renderobject, screen.renderlist)
+    filterrecursively!(plot)
 end
 
 function Base.empty!(screen::GLScreen)

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -63,9 +63,7 @@ end
 
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
     if !isempty(plot.plots)
-        # an AbstractPlot can have children, and only lowest-level children
-        # are saved in the renderlist, so we go down recursively until there
-        # are no more children to a plot object
+        # this plot consists of children, so we flatten it and delete the children instead
         delete!.(Ref(screen), Ref(scene), AbstractPlotting.flatten_plots(plot))
     else
         renderobject = get(screen.cache, objectid(plot)) do

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -66,7 +66,7 @@ function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
         # an AbstractPlot can have children, and only lowest-level children
         # are saved in the renderlist, so we go down recursively until there
         # are no more children to a plot object
-        delete!.(Ref(screen), Ref(scene), plot.plots)
+        delete!.(Ref(screen), Ref(scene), AbstractPlotting.flatten_plots(plot))
     else
         renderobject = get(screen.cache, objectid(plot)) do
             error("Could not find $(typeof(subplot)) in current GLMakie screen!")

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -62,21 +62,17 @@ function insertplots!(screen::GLScreen, scene::Scene)
 end
 
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
-
-    function filterrecursively!(plotobj)
-        if !isempty(plotobj.plots)
-            # an AbstractPlot can have children, and only lowest-level children
-            # are saved in the renderlist, so we go down recursively until there
-            # are no more children to a plot object
-            filterrecursively!.(plotobj.plots)
-        else
-            renderobject = get(screen.cache, objectid(plotobj)) do
-                error("Could not find $(typeof(subplot)) in current GLMakie screen!")
-            end
-            filter!(x-> x[3] !== renderobject, screen.renderlist)
+    if !isempty(plot.plots)
+        # an AbstractPlot can have children, and only lowest-level children
+        # are saved in the renderlist, so we go down recursively until there
+        # are no more children to a plot object
+        delete!.(Ref(screen), Ref(scene), plot.plots)
+    else
+        renderobject = get(screen.cache, objectid(plot)) do
+            error("Could not find $(typeof(subplot)) in current GLMakie screen!")
         end
+        filter!(x-> x[3] !== renderobject, screen.renderlist)
     end
-    filterrecursively!(plot)
 end
 
 function Base.empty!(screen::GLScreen)


### PR DESCRIPTION
a poly for example actually consists of a wireframe and a mesh, and the mesh consists of another mesh. only that last mesh and the wireframe exist in and can be deleted from the renderlist, not the higher level objects