### PR TITLE
update lighting

### DIFF
--- a/src/GLVisualize/assets/shader/attribute_mesh.vert
+++ b/src/GLVisualize/assets/shader/attribute_mesh.vert
@@ -4,12 +4,12 @@ in vec3 vertices;
 in vec3 normals;
 in float attribute_id;
 
-uniform vec3 light[4];
+uniform vec3 lightposition;
 
 uniform mat4 projection, view, model;
 uniform sampler1D attributes;
 
-void render(vec4 vertices, vec3 normals, mat4 view, mat4 projection, vec3 light[4]);
+void render(vec4 vertices, vec3 normals, mat4 view, mat4 projection, vec3 lightposition);
 
 uniform uint objectid;
 
@@ -22,5 +22,5 @@ void main()
 	o_uv = vec2(0.0);
 	o_id = uvec2(objectid, attribute_id+1);
 	o_color = texelFetch(attributes, int(attribute_id), 0);
-	render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, light);
+	render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, lightposition);
 }

--- a/src/GLVisualize/assets/shader/particles.vert
+++ b/src/GLVisualize/assets/shader/particles.vert
@@ -28,7 +28,7 @@ in vec3 vertices;
 in vec3 normals;
 {{texturecoordinates_type}} texturecoordinates;
 
-uniform vec3 light[4];
+uniform vec3 lightposition;
 uniform mat4 view, model, projection;
 uniform uint objectid;
 uniform int len;
@@ -125,7 +125,7 @@ vec4 _color(sampler2D color, Nothing intensity, Nothing color_map, Nothing color
     return vec4(0);
 }
 
-void render(vec4 vertices, vec3 normal, mat4 view, mat4 projection, vec3 light[4]);
+void render(vec4 vertices, vec3 normal, mat4 view, mat4 projection, vec3 lightposition);
 
 
 vec2 get_uv(Nothing x){return vec2(0.0);}
@@ -142,5 +142,5 @@ void main(){
     o_color    = _color(color, intensity, color_map, color_norm, index, len);
     o_uv = get_uv(texturecoordinates);
     rotate(rotation, index, V, N);
-    render(model * vec4(pos + V, 1), N, view, projection, light);
+    render(model * vec4(pos + V, 1), N, view, projection, lightposition);
 }

--- a/src/GLVisualize/assets/shader/standard.frag
+++ b/src/GLVisualize/assets/shader/standard.frag
@@ -4,9 +4,14 @@ struct Nothing{ //Nothing type, to encode if some variable doesn't contain any d
     bool _; //empty structs are not allowed
 };
 
+uniform vec3 ambient;
+uniform vec3 diffuse;
+uniform vec3 specular;
+uniform float shininess;
+
 in vec3 o_normal;
 in vec3 o_lightdir;
-in vec3 o_vertex;
+in vec3 o_camdir;
 in vec4 o_color;
 in vec2 o_uv;
 flat in uvec2 o_id;
@@ -36,17 +41,15 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
     float diff_coeff = max(dot(L, N), 0.0);
 
     // specular coefficient
-    vec3 H = normalize(L+V);
+    vec3 H = normalize(L + V);
 
-    float spec_coeff = pow(max(dot(H, N), 0.0), 8.0);
-    if (diff_coeff <= 0.0)
-        spec_coeff = 0.0;
+    float spec_coeff = pow(max(dot(H, N), 0.0), shininess);
 
     // final lighting model
     return vec3(
-        vec3(0.1) * vec3(0.3)  +
-        vec3(0.9) * color * diff_coeff +
-        vec3(0.3) * spec_coeff
+        ambient * color +
+        diffuse * diff_coeff * color +
+        specular * spec_coeff
     );
 }
 

--- a/src/GLVisualize/assets/shader/standard.vert
+++ b/src/GLVisualize/assets/shader/standard.vert
@@ -3,10 +3,11 @@
 in vec3 vertices;
 in vec3 normals;
 
-uniform vec3 light[4];
+
+uniform vec3 lightposition;
 uniform vec4 color;
 uniform mat4 projection, view, model;
-void render(vec4 vertices, vec3 normals, mat4 viewmodel, mat4 projection, vec3 light[4]);
+void render(vec4 vertices, vec3 normals, mat4 viewmodel, mat4 projection, vec3 lightposition);
 
 uniform uint objectid;
 flat out uvec2 o_id;
@@ -18,5 +19,5 @@ void main()
   o_id = uvec2(objectid, gl_VertexID+1);
   o_uv = vec2(0);
   o_color = color;
-  render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, light);
+  render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, lightposition);
 }

--- a/src/GLVisualize/assets/shader/surface.vert
+++ b/src/GLVisualize/assets/shader/surface.vert
@@ -19,7 +19,7 @@ in vec2 vertices;
 {{position_y_type}} position_y;
 uniform sampler2D position_z;
 
-uniform vec3 light[4];
+uniform vec3 lightposition;
 {{stroke_color_type}} stroke_color;
 {{glow_color_type}} glow_color;
 {{color_type}} color;
@@ -43,7 +43,7 @@ uniform vec3 scale;
 
 uniform mat4 view, model, projection;
 
-void render(vec4 vertices, vec3 normal, mat4 viewmodel, mat4 projection, vec3 light[4]);
+void render(vec4 vertices, vec3 normal, mat4 viewmodel, mat4 projection, vec3 lightposition);
 ivec2 ind2sub(ivec2 dim, int linearindex);
 vec2 linear_index(ivec2 dims, int index);
 vec2 linear_index(ivec2 dims, int index, vec2 offset);
@@ -106,6 +106,6 @@ void main()
     }else{
         o_uv = index01;
         vec3 normalvec = {{normal_calc}};
-        render(model * vec4(pos, 1), (model * vec4(normalvec, 0)).xyz, view, projection, light);
+        render(model * vec4(pos, 1), (model * vec4(normalvec, 0)).xyz, view, projection, lightposition);
     }
 }

--- a/src/GLVisualize/assets/shader/surface2.vert
+++ b/src/GLVisualize/assets/shader/surface2.vert
@@ -3,7 +3,7 @@
 
 in vec2 vertices;
 
-uniform vec3 light[4];
+uniform vec3 lightposition;
 {{color_type}} color;
 uniform vec2 color_norm;
 
@@ -16,7 +16,7 @@ uniform vec3 scale;
 
 uniform mat4 view, model, projection;
 
-void render(vec3 vertices, vec3 normal, vec4 color, mat4 viewmodel, mat4 projection, vec3 light[4]);
+void render(vec3 vertices, vec3 normal, vec4 color, mat4 viewmodel, mat4 projection, vec3 lightposition);
 ivec2 ind2sub(ivec2 dim, int linearindex);
 vec2 linear_index(ivec2 dims, int index, vec2 offset);
 vec4 linear_texture(sampler2D tex, int index, vec2 offset);
@@ -28,12 +28,12 @@ bool isinbounds(vec2 uv)
 	return (uv.x <= 1.0 && uv.y <= 1.0 && uv.x >= 0.0 && uv.y >= 0.0);
 }
 vec3 getnormal(sampler2D zvalues, vec2 uv)
-{   
+{
     float weps = 1.0/textureSize(zvalues,0).x;
     float heps = 1.0/textureSize(zvalues,0).y;
 
     vec3 result = vec3(0);
-    
+
     vec3 s0 = vec3(uv, texture(zvalues, uv).x);
 
     vec2 off1 = uv + vec2(-weps,0);
@@ -82,8 +82,6 @@ void main()
 
 	vec4 instance_color = color_lookup(pos.z, color, color_norm);
 	vec3 normalvec 		= getnormal(z, linear_index(dims, index, vertices));
-	render(pos, normalvec, instance_color, view * model, projection, light);
+	render(pos, normalvec, instance_color, view * model, projection, lightposition);
 	o_id                = uvec2(objectid, index+1);
 }
-
-

--- a/src/GLVisualize/assets/shader/util.vert
+++ b/src/GLVisualize/assets/shader/util.vert
@@ -227,18 +227,20 @@ vec4 _color(Nothing color, float intensity, sampler1D color_map, vec2 color_norm
 
 out vec3 o_normal;
 out vec3 o_lightdir;
-out vec3 o_vertex;
+out vec3 o_camdir;
 uniform mat3 normalmatrix;
+uniform vec3 lightposition;
+uniform vec3 eyeposition;
 
-void render(vec4 position_world, vec3 normal, mat4 view, mat4 projection, vec3 light[4])
+void render(vec4 position_world, vec3 normal, mat4 view, mat4 projection, vec3 lightposition)
 {
     // normal in world space
     // TODO move transpose inverse calculation to cpu
     o_normal               = normal;
     // direction to light
-    o_lightdir             = normalize(light[3] - position_world.xyz);
+    o_lightdir             = normalize(lightposition - position_world.xyz);
     // direction to camera
-    o_vertex               = -position_world.xyz;
+    o_camdir               = normalize(eyeposition - position_world.xyz);
     // screen space coordinates of the vertex
     gl_Position            = projection * view * position_world;
 }

--- a/src/GLVisualize/assets/shader/uv_normal.frag
+++ b/src/GLVisualize/assets/shader/uv_normal.frag
@@ -1,8 +1,14 @@
 {{GLSL_VERSION}}
 
+uniform vec3 ambient;
+uniform vec3 diffuse;
+uniform vec3 specular;
+uniform float shininess;
+
+
 in vec3 o_normal;
 in vec3 o_lightdir;
-in vec3 o_vertex;
+in vec3 o_camdir;
 in vec4 o_color;
 in vec2 o_uv;
 flat in uvec2 o_id;
@@ -18,15 +24,14 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color)
     // specular coefficient
     vec3 H = normalize(L+V);
 
-    float spec_coeff = pow(max(dot(H,N), 0.0), 8.0);
-    if (diff_coeff <= 0.0)
-        spec_coeff = 0.0;
+    float spec_coeff = pow(max(dot(H,N), 0.0), shininess);
 
     // final lighting model
-    return  vec3(
-            vec3(0.1)  * vec3(0.3)  +
-            vec3(0.9)  * color * diff_coeff +
-            vec3(0.3) * spec_coeff);
+    return vec3(
+        ambient * color +
+        diffuse * color * diff_coeff +
+        specular * spec_coeff
+    );
 }
 
 
@@ -55,9 +60,9 @@ void main(){
     vec3 L      	= normalize(o_lightdir);
     vec3 N 			= normalize(o_normal);
     vec3 f_color    = mix(vec3(0,0,1), vec3(1), square(o_uv));
-    vec3 light1 	= blinnphong(N, o_vertex, L, f_color);
-    vec3 light2 	= blinnphong(N, o_vertex, -L,f_color);
-    fragment_color 	= vec4(light1+light2*0.4, 1.0);
+    vec3 light1 	= blinnphong(N, o_camdir, L, f_color);
+    //vec3 light2 	= blinnphong(N, o_camdir, -L,f_color);
+    fragment_color 	= vec4(light1, 1.0); //+light2*0.4
     if(fragment_color.a > 0.0)
         fragment_groupid = o_id;
 }

--- a/src/GLVisualize/assets/shader/uv_normal.vert
+++ b/src/GLVisualize/assets/shader/uv_normal.vert
@@ -5,9 +5,9 @@ in vec3 normals;
 in vec2 texturecoordinates;
 
 
-uniform vec3 light[4];
+uniform vec3 lightposition;
 uniform mat4 projection, view, model;
-void render(vec4 vertices, vec3 normals, mat4 view, mat4 projection, vec3 light[4]);
+void render(vec4 vertices, vec3 normals, mat4 view, mat4 projection, vec3 lightposition);
 
 uniform uint objectid;
 flat out uvec2 o_id;
@@ -21,5 +21,5 @@ void main()
     o_uv = texturecoordinates;
     o_uv = vec2(1.0 - o_uv.y, o_uv.x);
 	o_id = uvec2(objectid, gl_VertexID+1);
-	render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, light);
+	render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, lightposition);
 }

--- a/src/GLVisualize/assets/shader/vertexcolor.vert
+++ b/src/GLVisualize/assets/shader/vertexcolor.vert
@@ -4,11 +4,11 @@ in vec3 vertices;
 in vec3 normals;
 in vec4 vertex_color;
 
-uniform vec3 light[4];
+uniform vec3 lightposition;
 
 uniform mat4 projection, view, model;
 
-void render(vec4 vertices, vec3 normals, mat4 view, mat4 projection, vec3 light[4]);
+void render(vec4 vertices, vec3 normals, mat4 view, mat4 projection, vec3 lightposition);
 
 uniform uint objectid;
 
@@ -21,5 +21,5 @@ void main()
     o_uv = vec2(0.0);
     o_id = uvec2(objectid, 0);
     o_color = vertex_color;
-    render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, light);
+    render(model * vec4(vertices, 1), (model * vec4(normals, 0)).xyz, view, projection, lightposition);
 }

--- a/src/GLVisualize/visualize/surface.jl
+++ b/src/GLVisualize/visualize/surface.jl
@@ -54,9 +54,9 @@ function light_calc(x::Bool)
         """
         vec3 L      = normalize(o_lightdir);
         vec3 N      = normalize(o_normal);
-        vec3 light1 = blinnphong(N, o_vertex, L, color.rgb);
-        vec3 light2 = blinnphong(N, o_vertex, -L, color.rgb);
-        color       = vec4(light1 + light2 * 0.4, color.a);
+        vec3 light1 = blinnphong(N, o_camdir, L, color.rgb);
+        //vec3 light2 = blinnphong(N, o_camdir, -L, color.rgb);
+        color       = vec4(light1, color.a); // + light2 * 0.4
         """
     else
         ""

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -2,11 +2,6 @@ function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f0(I)
-        ambient = Vec3f0(0.55)
-        diffuse = Vec3f0(0.4)
-        specular = Vec3f0(0.2)
-        shininess = 32f0
-        lightposition = :eyeposition
         preferred_camera = :perspective
         is_transparent_pass = Cint(false)
     end

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -2,11 +2,11 @@ function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f0(I)
-        ambient = Vec3f0(0.06)
-        diffuse = Vec3f0(0.8)
-        specular = Vec3f0(0.4)
-        shininess = 8f0
-        lightposition = Vec3f0(20)
+        ambient = Vec3f0(0.3)
+        diffuse = Vec3f0(0.65)
+        specular = Vec3f0(0.2)
+        shininess = 32f0
+        lightposition = Vec3f0(1f6)
         preferred_camera = :perspective
         is_transparent_pass = Cint(false)
     end

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -2,8 +2,8 @@ function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f0(I)
-        ambient = Vec3f0(0.3)
-        diffuse = Vec3f0(0.65)
+        ambient = Vec3f0(0.55)
+        diffuse = Vec3f0(0.4)
         specular = Vec3f0(0.2)
         shininess = 32f0
         lightposition = Vec3f0(1f6)

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -6,7 +6,7 @@ function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
         diffuse = Vec3f0(0.4)
         specular = Vec3f0(0.2)
         shininess = 32f0
-        lightposition = Vec3f0(1f6)
+        lightposition = :eyeposition
         preferred_camera = :perspective
         is_transparent_pass = Cint(false)
     end

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -1,10 +1,13 @@
-
+Vec3f0[Vec3f0(0), Vec3f0(0), Vec3f0(0)]
 function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
-    _default_light = Vec3f0[Vec3f0(1.0,1.0,1.0), Vec3f0(0.1,0.1,0.1), Vec3f0(0.9,0.9,0.9), Vec3f0(20,20,20)]
+    # _default_light = Vec3f0[Vec3f0(1.0,1.0,1.0), Vec3f0(0.1,0.1,0.1), Vec3f0(0.9,0.9,0.9), Vec3f0(20,20,20)]
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f0(I)
-        light = _default_light
+        ambient = Vec3f0(0.06)
+        diffuse = Vec3f0(0.8)
+        specular = Vec3f0(0.4)
+        shininess = 8f0
         preferred_camera = :perspective
         is_transparent_pass = Cint(false)
     end

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -1,5 +1,4 @@
 function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
-    # _default_light = Vec3f0[Vec3f0(1.0,1.0,1.0), Vec3f0(0.1,0.1,0.1), Vec3f0(0.9,0.9,0.9), Vec3f0(20,20,20)]
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f0(I)
@@ -7,6 +6,7 @@ function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
         diffuse = Vec3f0(0.8)
         specular = Vec3f0(0.4)
         shininess = 8f0
+        lightposition = Vec3f0(20)
         preferred_camera = :perspective
         is_transparent_pass = Cint(false)
     end

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -1,4 +1,3 @@
-Vec3f0[Vec3f0(0), Vec3f0(0), Vec3f0(0)]
 function default(@nospecialize(main), @nospecialize(s), @nospecialize(data))
     # _default_light = Vec3f0[Vec3f0(1.0,1.0,1.0), Vec3f0(0.1,0.1,0.1), Vec3f0(0.9,0.9,0.9), Vec3f0(20,20,20)]
     data = _default(main, s, copy(data))

--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -58,6 +58,9 @@ function cached_robj!(robj_func, screen, scene, x::AbstractPlot)
         for key in (:pixel_space, :view, :projection, :resolution, :eyeposition, :projectionview)
             robj[key] = getfield(scene.camera, key)
         end
+        if robj[:lightposition] == :eyeposition
+            robj[:lightposition] = getfield(scene.camera, :eyeposition)
+        end
         screen.cache2plot[robj.id] = x
         robj
     end

--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -54,12 +54,14 @@ function cached_robj!(robj_func, screen, scene, x::AbstractPlot)
                 gl_attributes[:offset] = lift(x-> AbstractPlotting.number.(x), gl_attributes[:offset])
             end
         end
+        if haskey(gl_attributes, :lightposition)
+            gl_attributes[:lightposition] = lift(gl_attributes[:lightposition]) do pos
+                ifelse(pos == :eyeposition, getfield(scene.camera, :eyeposition), pos)
+            end
+        end
         robj = robj_func(gl_attributes)
         for key in (:pixel_space, :view, :projection, :resolution, :eyeposition, :projectionview)
             robj[key] = getfield(scene.camera, key)
-        end
-        if robj[:lightposition] == :eyeposition
-            robj[:lightposition] = getfield(scene.camera, :eyeposition)
         end
         screen.cache2plot[robj.id] = x
         robj


### PR DESCRIPTION
I updated lighting/shading so that it can be controlled from Makie.

Changes:

- `light` attribute split into `ambient::Vec3f0`, `diffuse::Vec3f0`, `specular::Vec3f0`, `shininess::Float32` and `lightposition::Vec3f0`. The attributes `ambient` and `diffuse` are both multiplied element-wise with fragment color, `specular` is not (i.e it acts like a color itself).  
- `o_vertex = -vertex_position` changed to `o_camdir = eyeposition - vertex_position`
- removed mirrored light source. This may mess with some 3D surface plots depending on their normals!? (Though that should look messy now too.)
- removed `if (diff_coeff <= 0.0) spec_coeff = 0.0;`. So now specular reflection extend to the "dark side" rather then getting cut off. Doesn't make sense but looks better imo.

Example:

```julia
scene = mesh(
    Sphere(Point3f0(0.5), 0.1f0), 
    color=:red, 
    ambient = Vec3f0(0.15), 
    diffuse = Vec3f0(0.8), 
    specular = Vec3f0(0.6), 
    lightposition = Vec3f0(20000), 
    shininess = 16f0
)
```

![reflection_bleeding](https://user-images.githubusercontent.com/10947937/76165886-dcf1b380-615a-11ea-8267-acca10415936.png)