### PR TITLE
WIP: Allow `image` plot to do `nearest` interpolation

### DIFF
--- a/src/GLAbstraction/GLTypes.jl
+++ b/src/GLAbstraction/GLTypes.jl
@@ -327,9 +327,11 @@ function RenderObject(
             # glconvert is designed to just convert everything to a fitting opengl datatype, but sometimes exceptions are needed
             # e.g. Texture{T,1} and GLBuffer{T} are both usable as an native conversion canditate for a Julia's Array{T, 1} type.
             # but in some cases we want a Texture, sometimes a GLBuffer or TextureBuffer
-            data[k] = gl_convert(targets[k], v)
+            gl_convert_kwargs_dict = get(data, :gl_convert_kwargs, Dict())
+            gl_convert_kwargs_k = get(gl_convert_kwargs_dict, k, Dict())
+            data[k] = gl_convert(targets[k], v; gl_convert_kwargs_k...)
         else
-            k in (:indices, :visible, :fxaa) && continue
+            k in (:indices, :visible, :fxaa, :gl_convert_kwargs) && continue
             if isa_gl_struct(v) # structs are treated differently, since they have to be composed into their fields
                 merge!(data, gl_convert_struct(v, k))
             elseif applicable(gl_convert, v) # if can't be converted to an OpenGL datatype,

--- a/src/GLVisualize/visualize/image_like.jl
+++ b/src/GLVisualize/visualize/image_like.jl
@@ -17,7 +17,7 @@ function _default(main::MatTypes{T}, ::Style, data::Dict) where T <: Colorant
         end
     end
     delete!(data, :ranges)
-    @gen_defaults! data begin
+    return @gen_defaults! data begin
         image = main => (Texture, "image, can be a Texture or Array of colors")
         primitive::GLUVMesh2D = const_lift(ranges) do r
             x, y = minimum(r[1]), minimum(r[2])

--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -300,7 +300,12 @@ function draw_atomic(screen::GLScreen, scene::Scene, x::Image)
         gl_attributes[:ranges] = lift(to_range, x[1], x[2])
         img = get_image(gl_attributes)
         # remove_automatic!(gl_attributes)
-        visualize(img, Style(:default), gl_attributes).children[]
+        interp = to_value(get(gl_attributes, :interpolation, :linear))
+        delete!(gl_attributes, :interpolation)
+        a = GLVisualize.default(img, Style(:default), gl_attributes)
+        a[:gl_convert_kwargs] = Dict()
+        a[:gl_convert_kwargs][:image] = Dict(:minfilter=>interp, :magfilter=>interp)
+        GLVisualize.assemble_shader(a).children[]
     end
 end
 


### PR DESCRIPTION
Allow

```julia
import GLMakie: AbstractPlotting
import .AbstractPlotting: Scene, image!
import .AbstractPlotting.Observables

scene = Scene()
o = Observables.Observable(rand(10, 10))
im = image!(scene, o; interpolation=:nearest)
```

This is a very rough sketch, but it would be nice to have some "escape hatch" [1] functionality across some of the abstraction layers. I don't know a great design to accomplish this, but I think processing and mutating`Dict{Symbol, Any}`, as is currently being done, is a flexible pattern to allow parameters that modify attributes at different layers of abstraction.

Relying on the escape hatch mechanism of a lower layer would always be a last-resort solution for the higher layer. And if such an escape hatch is presented to the highest `AbstractPlotting` layer, it would be 100% back-end specific, and there shouldn't be much effort to preserve backward compatibility. I didn't carry out the idea to the fullest in this PR, but if I did, it would be something like: 
`image!(scene, o; var"image.minfilter"=:nearest, var"image.magfilter"=:nearest)

And it would be fair game for `GLMakie` to change `image` to another symbol, and have that code break.

(This is the first time I'm using`var`. If someone else is also unfamiliar:

```julia
julia> f(;kwargs...) = kwargs
f (generic function with 1 method)

julia> f(h=5)
pairs(::NamedTuple) with 1 entry:
  :h => 5

julia> f(var"h"=5)
pairs(::NamedTuple) with 1 entry:
  :h => 5

julia> f(var"h.h"=5)
pairs(::NamedTuple) with 1 entry:
  Symbol("h.h") => 5
```

[1] https://wiki.c2.com/?EscapeHatch