### PR TITLE
Dispatch PollEvents on screen type

### DIFF
--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -37,7 +37,7 @@ make_context_current(screen::Screen) = GLFW.MakeContextCurrent(to_native(screen)
 
 function cached_robj!(robj_func, screen, scene, x::AbstractPlot)
     # poll inside functions to make wait on compile less prominent
-    GLFW.PollEvents()
+    pollevents(screen)
     robj = get!(screen.cache, objectid(x)) do
 
         filtered = filter(x.attributes) do (k, v)
@@ -156,13 +156,13 @@ end
 
 function Base.insert!(screen::GLScreen, scene::Scene, x::Combined)
     # poll inside functions to make wait on compile less prominent
-    GLFW.PollEvents()
+    pollevents(screen)
     if isempty(x.plots) # if no plots inserted, this truely is an atomic
         draw_atomic(screen, scene, x)
     else
         foreach(x.plots) do x
             # poll inside functions to make wait on compile less prominent
-            GLFW.PollEvents()
+            pollevents(screen)
             insert!(screen, scene, x)
         end
     end

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -174,7 +174,7 @@ function id2scene(screen, id1)
     return false, nothing
 end
 
-function GLAbstraction.render(screen::Screen, fxaa::Bool, ssao::Bool=false)
+function GLAbstraction.render(screen::GLScreen, fxaa::Bool, ssao::Bool=false)
     # Somehow errors in here get ignored silently!?
     try
         # sort by overdraw, so that overdrawing objects get drawn last!

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -3,7 +3,7 @@ function renderloop(screen::Screen; framerate = 1/30, prerender = () -> nothing)
     try
         while isopen(screen)
             t = time()
-            GLFW.PollEvents() # GLFW poll
+            pollevents(screen) # GLFW poll
             screen.render_tick[] = nothing
             prerender()
             make_context_current(screen)

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -120,9 +120,9 @@ end
 function AbstractPlotting.backend_display(screen::Screen, scene::Scene)
     empty!(screen)
     register_callbacks(scene, screen)
-    GLFW.PollEvents()
+    pollevents(screen)
     insertplots!(screen, scene)
-    GLFW.PollEvents()
+    pollevents(screen)
     screen.displayed_scene = scene
     return
 end
@@ -452,3 +452,6 @@ function AbstractPlotting.pick(screen::Screen, rect::IRect2D)
     end
     return Tuple{AbstractPlot, Int}[]
 end
+
+pollevents(::GLScreen) = nothing
+pollevents(::Screen) = GLFW.PollEvents()


### PR DESCRIPTION
This change makes event polling a no-op by default and calls `GLFW.PollEvents()` as before in the case of a `GLMakie.Screen`.

The reason for this change is that calling `GLFW.PollEvents` hangs when GLFW is not actually used for the screen, as in QML.jl in my case.