### PR TITLE
Renderloop control

### DIFF
--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -2,18 +2,22 @@ function renderloop(screen::Screen; framerate = 1/30, prerender = () -> nothing)
     # Somehow errors get sometimes ignored, so we at least print them here
     try
         while isopen(screen)
-            t = time()
-            GLFW.PollEvents() # GLFW poll
-            screen.render_tick[] = nothing
-            prerender()
-            make_context_current(screen)
-            render_frame(screen)
-            GLFW.SwapBuffers(to_native(screen))
-            diff = framerate - (time() - t)
-            if diff > 0
-                sleep(diff)
-            else # if we don't sleep, we need to yield explicitely
-                yield()
+            if opengl_renderloop_enabled[]
+                t = time()
+                GLFW.PollEvents() # GLFW poll
+                screen.render_tick[] = nothing
+                prerender()
+                make_context_current(screen)
+                render_frame(screen)
+                GLFW.SwapBuffers(to_native(screen))
+                diff = framerate - (time() - t)
+                if diff > 0
+                    sleep(diff)
+                else # if we don't sleep, we need to yield explicitely
+                    yield()
+                end
+            else
+                sleep(framerate)
             end
         end
     catch e

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -6,11 +6,16 @@ function _render(screen::Screen; prerender = () -> nothing)
     render_frame(screen)
     GLFW.SwapBuffers(to_native(screen))
 end
-function renderloop(screen::Screen; framerate = 30, prerender = () -> nothing)
+function renderloop(screen::Screen; prerender = () -> nothing)
     # Somehow errors get sometimes ignored, so we at least print them here
     try
-        t = Timer(0, interval = 1 / framerate)
+        framerate = opengl_renderloop_framerate[]
+        t = Timer(0, interval = 1 / framerate) 
         while isopen(screen)
+            if framerate != opengl_renderloop_framerate[] # update timer if framerate changed
+                framerate =  opengl_renderloop_framerate[]
+                t = Timer(0, interval = 1 / framerate)
+            end
             if opengl_renderloop_enabled[]
                 _render(screen, prerender = prerender)
             end

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -1,4 +1,4 @@
-function _render(screen::Screen)
+function _render(screen::Screen; prerender = () -> nothing)
     GLFW.PollEvents() # GLFW poll
     screen.render_tick[] = nothing
     prerender()
@@ -12,7 +12,7 @@ function renderloop(screen::Screen; framerate = 30, prerender = () -> nothing)
         t = Timer(0, interval = 1 / framerate)
         while isopen(screen)
             if opengl_renderloop_enabled[]
-                _render(screen)
+                _render(screen, prerender = prerender)
             end
             if isopen(t)
                 wait(t)

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -1,4 +1,4 @@
-function renderloop(screen::Screen; framerate = 1/30, prerender = () -> nothing)
+function renderloop(screen::Screen; framerate = 30, prerender = () -> nothing)
     # Somehow errors get sometimes ignored, so we at least print them here
     try
         while isopen(screen)

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -1,11 +1,3 @@
-function _render(screen::Screen; prerender = () -> nothing)
-    GLFW.PollEvents() # GLFW poll
-    screen.render_tick[] = nothing
-    prerender()
-    make_context_current(screen)
-    render_frame(screen)
-    GLFW.SwapBuffers(to_native(screen))
-end
 function renderloop(screen::Screen; prerender = () -> nothing)
     # Somehow errors get sometimes ignored, so we at least print them here
     try
@@ -16,8 +8,13 @@ function renderloop(screen::Screen; prerender = () -> nothing)
                 framerate =  opengl_renderloop_framerate[]
                 t = Timer(0, interval = 1 / framerate)
             end
+            GLFW.PollEvents() # GLFW poll
+            screen.render_tick[] = nothing
             if opengl_renderloop_enabled[]
-                _render(screen, prerender = prerender)
+                prerender()
+                make_context_current(screen)
+                render_frame(screen)
+                GLFW.SwapBuffers(to_native(screen))
             end
             if isopen(t)
                 wait(t)

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -217,9 +217,14 @@ function renderloop end
 # the rendering loop
 const opengl_renderloop = Ref{Function}(renderloop)
 const opengl_renderloop_enabled = Ref{Bool}(true)
+const opengl_renderloop_framerate = Ref{Real}(30.0)
 
 function enable_renderloop!(enable::Bool) 
     opengl_renderloop_enabled[] = enable
+end
+
+function renderloop_framerate!(framerate::Real)
+    opengl_renderloop_framerate[] = framerate
 end
 
 """

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -216,6 +216,11 @@ function renderloop end
 # TODO a global is not very nice, but it's the simplest way right now to swap out
 # the rendering loop
 const opengl_renderloop = Ref{Function}(renderloop)
+const opengl_renderloop_enabled = Ref{Bool}(true)
+
+function enable_renderloop!(enable::Bool) 
+    opengl_renderloop_enabled[] = enable
+end
 
 """
 Julia 1.0.3 doesn't have I:J, so we copy the implementation from 1.1 under a new name:


### PR DESCRIPTION
This is designed to allow enabling/disabling the renderloop via `GLMakie.enable_renderloop!(enable::Bool)`

I assume it would be helpful for situations where you only want rendering to be triggered by an observable or an animation loop (I noticed the renderloop runs freely during record loop, which seems unnecessary?)

I also tried to add a discrete `_render()` function but couldn't work out a high-level way to pass `screen` to this function. That could provide a single-shot render trigger for observable updates?


Note: the value of the  `framerate` kwarg in renderloop was set as `1/30`, which was being used as a frame period,  so I fixed that. Also switched out the renderloop  timing for a `Timer` with a recurring interval

For instance, the additional `Makie.GLMakie.enable_renderloop!(false)` in this example still results in the same video output, without rendering the window on screen

```
using Makie

scene = Scene()
mytime = Node(0.0)
f(v, t) = sin(v + t)
scene = lines!(
    scene,
    lift(t -> f.(range(0, stop = 2pi, length = 50), t), mytime),
    color = :blue)
p1 = scene[end];
N = 100

Makie.GLMakie.enable_renderloop!(false)

@time record(scene, "output.mp4", range(0, stop = 4pi, length = N)) do i
    mytime[] = i
end
```