### PR TITLE
Make buffer length error more descriptive

### DIFF
--- a/src/GLAbstraction/GLTypes.jl
+++ b/src/GLAbstraction/GLTypes.jl
@@ -203,10 +203,21 @@ function GLVertexArray(bufferdict::Dict, program::GLProgram)
             attribute = string(name)
             len == -1 && (len = length(buffer))
             # TODO: use glVertexAttribDivisor to allow multiples of the longest buffer
-            len != length(buffer) && error(
-              "buffer $attribute has not the same length as the other buffers.
-              Has: $(length(buffer)). Should have: $len"
-            )
+            if len != length(buffer)
+                # We don't know which buffer has the wrong size, so list all of them
+                bufferlengths = ""
+                for (name, buffer) in bufferdict
+                    if isa(buffer, GLBuffer) && buffer.buffertype == GL_ELEMENT_ARRAY_BUFFER
+                    elseif Symbol(name) == :indices
+                    else
+                        bufferlengths *= "\n\t$name has length $(length(buffer))"
+                    end
+                end
+                error(
+                    "Buffer $attribute does not have the same length as the other buffers." *
+                    bufferlengths
+                )
+            end
             bind(buffer)
             attribLocation = get_attribute_location(program.id, attribute)
             (attribLocation == -1) && continue


### PR DESCRIPTION
Before:
```julia
julia> scatter([1], color=[:red, :green, :blue]))
ERROR: LoadError: buffer position has not the same length as the other buffers.
              Has: 1. Should have: 3
```

After:
```julia
julia> scatter([1], color=[:red, :green, :blue]))
ERROR: Buffer position does not have the same length as the other buffers.
	color has length 3
	position has length 1
```