### PR TITLE
allow color meshes in meshscatter

### DIFF
--- a/src/GLVisualize/assets/shader/particles.vert
+++ b/src/GLVisualize/assets/shader/particles.vert
@@ -85,6 +85,11 @@ vec3 _scale(vec3 scale, Nothing scale_x, Nothing scale_y, Nothing scale_z, int i
 {{color_map_type}}  color_map;
 {{intensity_type}}  intensity;
 {{color_norm_type}} color_norm;
+{{vertex_color_type}} vertex_color;
+vec4 to_color(Nothing c){return vec4(1, 1, 1, 1);}
+vec4 to_color(vec3 c){return vec4(c, 1);}
+vec4 to_color(vec4 c){return c;}
+
 // constant color!
 vec4 _color(vec4 color, Nothing intensity, Nothing color_map, Nothing color_norm, int index, int len);
 vec4 _color(vec3 color, Nothing intensity, Nothing color_map, Nothing color_norm, int index, int len);
@@ -138,6 +143,7 @@ void main(){
     vec3 pos;
     {{position_calc}}
     o_color    = _color(color, intensity, color_map, color_norm, index, len);
+    o_color = o_color * to_color(vertex_color);
     o_uv = get_uv(texturecoordinates);
     rotate(rotation, index, V, N);
     render(model * vec4(pos + V, 1), N, view, projection, lightposition);

--- a/src/GLVisualize/visualize/particles.jl
+++ b/src/GLVisualize/visualize/particles.jl
@@ -96,6 +96,7 @@ function meshparticle(p, s, data)
         else
             nothing
         end => to_meshcolor
+        vertex_color = Vec4f0(1)
         fetch_pixel = false
         uv_scale = Vec2f0(1)
 


### PR DESCRIPTION
With this the `color` attribute of a mesh gets used in meshscatter. The `color` attribute of the plot gets multiplier with the mesh color, so it acts like a filter.

```julia
using Makie, GeometryBasics
ps = [Point3f0(x, y, z) for x in 0:1, y in 0:1, z in 0:1][:]
m = normal_mesh(Sphere(Point3f0(0), 1f0))
mc = GeometryBasics.Mesh(meta(coordinates(m), normals=normals(m), color = rand(RGBf0, length(coordinates(m)))), faces(m))
s1 = meshscatter(ps, marker=m, markersize=0.1)
s2 = meshscatter(ps, marker=m, markersize=0.1, color=:red)
s3 = meshscatter(ps, marker=mc, markersize=0.1, color=:white)
s4 = meshscatter(ps, marker=mc, markersize=0.1, color=:red)
hbox(vbox(s3, s4), vbox(s1, s2))
```
![Screenshot from 2020-07-13 00-01-16](https://user-images.githubusercontent.com/10947937/87257534-040b1980-c49c-11ea-8f3d-76992f4b362c.png)
