### PR TITLE
Add a flag to exit the render loop early

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -1,6 +1,6 @@
 
 function vsynced_renderloop(screen)
-    while isopen(screen)
+    while isopen(screen) && !WINDOW_CONFIG.exit_renderloop[]
         pollevents(screen) # GLFW poll
         screen.render_tick[] = nothing
         if WINDOW_CONFIG.pause_rendering[]
@@ -16,7 +16,7 @@ end
 
 function fps_renderloop(screen::Screen, framerate=WINDOW_CONFIG.framerate[])
     time_per_frame = 1.0 / framerate
-    while isopen(screen)
+    while isopen(screen) && !WINDOW_CONFIG.exit_renderloop[]
         t = time_ns()
         pollevents(screen) # GLFW poll
         screen.render_tick[] = nothing
@@ -61,9 +61,9 @@ const WINDOW_CONFIG = (
     pause_rendering = Ref(false),
     focus_on_show = Ref(false),
     decorated = Ref(true),
-    title = Ref("Makie")
+    title = Ref("Makie"),
+    exit_renderloop = Ref(false),
 )
-
 
 """
     set_window_config!(;


### PR DESCRIPTION
This PR adds a flag `exit_renderloop` that lets the user exit the render loop early. This is a workaround for issue https://github.com/JuliaPlots/Makie.jl/issues/645. I have tested this in the same environment that caused me to report https://github.com/JuliaPlots/Makie.jl/issues/645 and it works when I use it like this:
```julia
GLMakie.set_window_config!(vsync = false, framerate = 1, exit_renderloop = false)
plot = scatter(1:4) # do some plotting...
GLMakie.destroy!.(plot.current_screens)
GLMakie.set_window_config!(exit_renderloop = true)
```

CC @ianshmean