### PR TITLE
Fix for Makie#614

### DIFF
--- a/src/GLVisualize/assets/shader/fragment_output.frag
+++ b/src/GLVisualize/assets/shader/fragment_output.frag
@@ -3,7 +3,7 @@
 layout(location=0) out vec4 fragment_color;
 layout(location=1) out uvec2 fragment_groupid;
 layout(location=2) out vec4 fragment_position;
-layout(location=3) out vec4 fragment_normal;
+layout(location=3) out vec4 fragment_normal_occlusion;
 
 in vec4 o_view_pos;
 in vec3 o_normal;
@@ -17,5 +17,5 @@ void write2framebuffer(vec4 color, uvec2 id){
     fragment_groupid = id;
     // For SSAO
     fragment_position = o_view_pos;
-    fragment_normal.xyz = o_normal;
+    fragment_normal_occlusion.xyz = o_normal;
 }

--- a/src/GLVisualize/assets/shader/fragment_output.frag
+++ b/src/GLVisualize/assets/shader/fragment_output.frag
@@ -3,7 +3,7 @@
 layout(location=0) out vec4 fragment_color;
 layout(location=1) out uvec2 fragment_groupid;
 layout(location=2) out vec4 fragment_position;
-layout(location=3) out vec3 fragment_normal;
+layout(location=3) out vec4 fragment_normal;
 
 in vec4 o_view_pos;
 in vec3 o_normal;
@@ -17,5 +17,5 @@ void write2framebuffer(vec4 color, uvec2 id){
     fragment_groupid = id;
     // For SSAO
     fragment_position = o_view_pos;
-    fragment_normal = o_normal;
+    fragment_normal.xyz = o_normal;
 }

--- a/src/GLVisualize/assets/shader/postprocessing/SSAO.frag
+++ b/src/GLVisualize/assets/shader/postprocessing/SSAO.frag
@@ -15,7 +15,8 @@ uniform float radius;
 
 
 in vec2 frag_uv;
-out float o_occlusion;
+// occlusion.xyz is a normal vector, occlusion.w the occlusion value
+out vec4 o_occlusion;
 
 
 void main(void)
@@ -83,8 +84,8 @@ void main(void)
             occlusion += (sample_depth >= sample_view_offset.z + view_pos.z + bias ? 1.0 : 0.0) * range_check;
         }
         occlusion = 1.0 - (occlusion / {{N_samples}});
-        o_occlusion = occlusion;
+        o_occlusion.w = occlusion;
     } else {
-        o_occlusion = 1.0;
+        o_occlusion.w = 1.0;
     }
 }

--- a/src/GLVisualize/assets/shader/postprocessing/SSAO.frag
+++ b/src/GLVisualize/assets/shader/postprocessing/SSAO.frag
@@ -2,7 +2,7 @@
 
 // SSAO
 uniform sampler2D position_buffer;
-uniform sampler2D normal_buffer;
+uniform sampler2D normal_occlusion_buffer;
 uniform sampler2D noise;
 uniform vec3 kernel[{{N_samples}}];
 uniform vec2 noise_scale;
@@ -16,13 +16,13 @@ uniform float radius;
 
 in vec2 frag_uv;
 // occlusion.xyz is a normal vector, occlusion.w the occlusion value
-out vec4 o_occlusion;
+out vec4 o_normal_occlusion;
 
 
 void main(void)
 {
     vec3 view_pos = texture(position_buffer, frag_uv).xyz;
-    vec3 normal  = texture(normal_buffer, frag_uv).xyz;
+    vec3 normal  = texture(normal_occlusion_buffer, frag_uv).xyz;
 
     // The normal buffer gets cleared every frame. (also position, color etc)
     // If normal == vec3(1) then there is no geometry at this fragment.
@@ -84,8 +84,8 @@ void main(void)
             occlusion += (sample_depth >= sample_view_offset.z + view_pos.z + bias ? 1.0 : 0.0) * range_check;
         }
         occlusion = 1.0 - (occlusion / {{N_samples}});
-        o_occlusion.w = occlusion;
+        o_normal_occlusion.w = occlusion;
     } else {
-        o_occlusion.w = 1.0;
+        o_normal_occlusion.w = 1.0;
     }
 }

--- a/src/GLVisualize/assets/shader/postprocessing/SSAO_blur.frag
+++ b/src/GLVisualize/assets/shader/postprocessing/SSAO_blur.frag
@@ -1,5 +1,6 @@
 {{GLSL_VERSION}}
 
+// occlusion.w is the occlusion value
 uniform sampler2D occlusion;
 uniform sampler2D color_texture;
 uniform usampler2D ids;
@@ -26,7 +27,7 @@ void main(void)
               // shine effect.
               uvec2 id = texture(ids, frag_uv + offset).xy;
               if (id0 == id) {
-                  blurred_occlusion += texture(occlusion, frag_uv + offset).r;
+                  blurred_occlusion += texture(occlusion, frag_uv + offset).w;
                   weight += 1;
               }
           }

--- a/src/GLVisualize/assets/shader/postprocessing/SSAO_blur.frag
+++ b/src/GLVisualize/assets/shader/postprocessing/SSAO_blur.frag
@@ -1,7 +1,7 @@
 {{GLSL_VERSION}}
 
 // occlusion.w is the occlusion value
-uniform sampler2D occlusion;
+uniform sampler2D normal_occlusion;
 uniform sampler2D color_texture;
 uniform usampler2D ids;
 uniform vec2 inv_texel_size;
@@ -27,7 +27,7 @@ void main(void)
               // shine effect.
               uvec2 id = texture(ids, frag_uv + offset).xy;
               if (id0 == id) {
-                  blurred_occlusion += texture(occlusion, frag_uv + offset).w;
+                  blurred_occlusion += texture(normal_occlusion, frag_uv + offset).w;
                   weight += 1;
               }
           }

--- a/src/glwindow.jl
+++ b/src/glwindow.jl
@@ -36,10 +36,8 @@ mutable struct GLFramebuffer
     depth::Texture{GLAbstraction.DepthStencil_24_8, 2}
     position::Texture{Vec4f0, 2}
     # NOTE: temporary fix for https://github.com/JuliaPlots/Makie.jl/issues/614
-    normal::Texture{Vec4f0, 2}
-    # normal::Texture{Vec3f0, 2}
+    normal_occlusion::Texture{Vec4f0, 2}
     ssao_noise::Texture{Vec2f0, 2}
-    # occlusion::Texture{Float32, 2}
 
     color_luma::Texture{RGBA{N0f8}, 2}
 
@@ -59,7 +57,7 @@ to the screen and while at it, it can do some postprocessing (not doing it right
 E.g fxaa anti aliasing, color correction etc.
 """
 function postprocess(
-        color, position, normal, ssao_noise, #occlusion,
+        color, position, normal_occlusion, ssao_noise,
         objectid, color_luma,
         framebuffer_size
     )
@@ -84,7 +82,7 @@ function postprocess(
     )
     data1 = Dict{Symbol, Any}(
         :position_buffer => position,
-        :normal_buffer => normal,
+        :normal_occlusion_buffer => normal_occlusion,
         :kernel => kernel,
         :noise => ssao_noise,
         :noise_scale => map(s -> Vec2f0(s ./ 4.0), framebuffer_size),
@@ -102,8 +100,7 @@ function postprocess(
         loadshader("postprocessing/SSAO_blur.frag")
     )
     data2 = Dict{Symbol, Any}(
-        # :occlusion => occlusion,
-        :occlusion => normal,
+        :normal_occlusion => normal_occlusion,
         :color_texture => color,
         :ids => objectid,
         :inv_texel_size => map(t -> Vec2f0(1f0/t[1], 1f0/t[2]), framebuffer_size),
@@ -166,9 +163,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     objectid_buffer = Texture(Vec{2, GLushort}, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
     position_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
     # NOTE: temporary fix for https://github.com/JuliaPlots/Makie.jl/issues/614
-    normal_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
-    # normal_buffer = Texture(Vec3f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
-    # occlusion = Texture(Float32, fb_size, minfilter=:nearest, x_repeat=:clamp_to_edge)
+    normal_occlusion_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
 
     depth_buffer = Texture(
         Ptr{GLAbstraction.DepthStencil_24_8}(C_NULL), fb_size,
@@ -185,8 +180,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     attach_framebuffer(color_buffer, GL_COLOR_ATTACHMENT0)
     attach_framebuffer(objectid_buffer, GL_COLOR_ATTACHMENT1)
     attach_framebuffer(position_buffer, GL_COLOR_ATTACHMENT2)
-    attach_framebuffer(normal_buffer, GL_COLOR_ATTACHMENT3)
-    # attach_framebuffer(occlusion, GL_COLOR_ATTACHMENT4)
+    attach_framebuffer(normal_occlusion_buffer, GL_COLOR_ATTACHMENT3)
     attach_framebuffer(depth_buffer, GL_DEPTH_ATTACHMENT)
     attach_framebuffer(depth_buffer, GL_STENCIL_ATTACHMENT)
 
@@ -207,7 +201,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     fb_size_node = Node(fb_size)
 
     p = postprocess(
-        color_buffer, position_buffer, normal_buffer, ssao_noise, #occlusion,
+        color_buffer, position_buffer, normal_occlusion_buffer, ssao_noise, #occlusion,
         objectid_buffer, color_luma,
         fb_size_node
     )
@@ -216,7 +210,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
         fb_size_node,
         (render_framebuffer, color_luma_framebuffer),
         color_buffer, objectid_buffer, depth_buffer,
-        position_buffer, normal_buffer, ssao_noise,# occlusion,
+        position_buffer, normal_occlusion_buffer, ssao_noise,# occlusion,
         color_luma,
         p
     )
@@ -229,8 +223,7 @@ function Base.resize!(fb::GLFramebuffer, window_size)
         resize_nocopy!(fb.objectid, ws)
         resize_nocopy!(fb.depth, ws)
         resize_nocopy!(fb.position, ws)
-        resize_nocopy!(fb.normal, ws)
-        # resize_nocopy!(fb.occlusion, ws)
+        resize_nocopy!(fb.normal_occlusion, ws)
         resize_nocopy!(fb.color_luma, ws)
         fb.resolution[] = ws
     end

--- a/src/glwindow.jl
+++ b/src/glwindow.jl
@@ -35,9 +35,11 @@ mutable struct GLFramebuffer
     objectid::Texture{Vec{2, GLushort}, 2}
     depth::Texture{GLAbstraction.DepthStencil_24_8, 2}
     position::Texture{Vec4f0, 2}
-    normal::Texture{Vec3f0, 2}
+    # NOTE: temporary fix for https://github.com/JuliaPlots/Makie.jl/issues/614
+    normal::Texture{Vec4f0, 2}
+    # normal::Texture{Vec3f0, 2}
     ssao_noise::Texture{Vec2f0, 2}
-    occlusion::Texture{Float32, 2}
+    # occlusion::Texture{Float32, 2}
 
     color_luma::Texture{RGBA{N0f8}, 2}
 
@@ -57,7 +59,8 @@ to the screen and while at it, it can do some postprocessing (not doing it right
 E.g fxaa anti aliasing, color correction etc.
 """
 function postprocess(
-        color, position, normal, ssao_noise, occlusion, objectid, color_luma,
+        color, position, normal, ssao_noise, #occlusion,
+        objectid, color_luma,
         framebuffer_size
     )
 
@@ -99,7 +102,8 @@ function postprocess(
         loadshader("postprocessing/SSAO_blur.frag")
     )
     data2 = Dict{Symbol, Any}(
-        :occlusion => occlusion,
+        # :occlusion => occlusion,
+        :occlusion => normal,
         :color_texture => color,
         :ids => objectid,
         :inv_texel_size => map(t -> Vec2f0(1f0/t[1], 1f0/t[2]), framebuffer_size),
@@ -161,8 +165,10 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     color_buffer = Texture(RGBA{N0f8}, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
     objectid_buffer = Texture(Vec{2, GLushort}, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
     position_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
-    normal_buffer = Texture(Vec3f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
-    occlusion = Texture(Float32, fb_size, minfilter=:nearest, x_repeat=:clamp_to_edge)
+    # NOTE: temporary fix for https://github.com/JuliaPlots/Makie.jl/issues/614
+    normal_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
+    # normal_buffer = Texture(Vec3f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
+    # occlusion = Texture(Float32, fb_size, minfilter=:nearest, x_repeat=:clamp_to_edge)
 
     depth_buffer = Texture(
         Ptr{GLAbstraction.DepthStencil_24_8}(C_NULL), fb_size,
@@ -180,7 +186,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     attach_framebuffer(objectid_buffer, GL_COLOR_ATTACHMENT1)
     attach_framebuffer(position_buffer, GL_COLOR_ATTACHMENT2)
     attach_framebuffer(normal_buffer, GL_COLOR_ATTACHMENT3)
-    attach_framebuffer(occlusion, GL_COLOR_ATTACHMENT4)
+    # attach_framebuffer(occlusion, GL_COLOR_ATTACHMENT4)
     attach_framebuffer(depth_buffer, GL_DEPTH_ATTACHMENT)
     attach_framebuffer(depth_buffer, GL_STENCIL_ATTACHMENT)
 
@@ -201,7 +207,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     fb_size_node = Node(fb_size)
 
     p = postprocess(
-        color_buffer, position_buffer, normal_buffer, ssao_noise, occlusion,
+        color_buffer, position_buffer, normal_buffer, ssao_noise, #occlusion,
         objectid_buffer, color_luma,
         fb_size_node
     )
@@ -210,7 +216,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
         fb_size_node,
         (render_framebuffer, color_luma_framebuffer),
         color_buffer, objectid_buffer, depth_buffer,
-        position_buffer, normal_buffer, ssao_noise, occlusion,
+        position_buffer, normal_buffer, ssao_noise,# occlusion,
         color_luma,
         p
     )
@@ -224,7 +230,7 @@ function Base.resize!(fb::GLFramebuffer, window_size)
         resize_nocopy!(fb.depth, ws)
         resize_nocopy!(fb.position, ws)
         resize_nocopy!(fb.normal, ws)
-        resize_nocopy!(fb.occlusion, ws)
+        # resize_nocopy!(fb.occlusion, ws)
         resize_nocopy!(fb.color_luma, ws)
         fb.resolution[] = ws
     end

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -150,10 +150,11 @@ function render_frame(screen::Screen; resize_buffers=true)
 
 
     # SSAO - calculate occlusion
-    glDrawBuffer(GL_COLOR_ATTACHMENT4)  # occlusion buffer
+    # glDrawBuffer(GL_COLOR_ATTACHMENT4)  # occlusion buffer
+    glDrawBuffer(GL_COLOR_ATTACHMENT3)  # occlusion buffer
     glViewport(0, 0, w, h)
-    glClearColor(1, 1, 1, 1)            # 1 means no darkening
-    glClear(GL_COLOR_BUFFER_BIT)
+    # glClearColor(1, 1, 1, 1)            # 1 means no darkening
+    # glClear(GL_COLOR_BUFFER_BIT)
 
     for (screenid, scene) in screen.screens
         # update uniforms


### PR DESCRIPTION
This combines the `normal` and `occlusion` buffer to one so that we don't use `Texture{Vec3f0}` anymore. See https://github.com/JuliaPlots/Makie.jl/issues/614

Seems to be working fine with ssao on.
```julia
meshscatter(rand(Point3f0, 100), ssao=true, color=:white, shading=false)
```
![Screenshot from 2020-07-17 22-26-34](https://user-images.githubusercontent.com/10947937/87828205-bff18d80-c87c-11ea-9aab-4a03cc59e18d.png)