### PR TITLE
add basic matcap functionality

### DIFF
--- a/src/GLVisualize/assets/shader/standard.frag
+++ b/src/GLVisualize/assets/shader/standard.frag
@@ -17,20 +17,38 @@ in vec2 o_uv;
 flat in uvec2 o_id;
 
 {{image_type}} image;
+{{matcap_type}} matcap;
 {{color_range_type}} color_range;
 
-vec4 get_color(Nothing image, vec2 uv, Nothing color_range){
+vec4 get_color(Nothing image, vec2 uv, Nothing color_range, Nothing matcap){
     return o_color;
 }
 
-vec4 get_color(sampler2D color, vec2 uv, Nothing color_range){
+vec4 get_color(sampler2D color, vec2 uv, Nothing color_range, Nothing matcap){
     return texture(color, uv);
 }
 
-vec4 get_color(sampler1D color, vec2 uv, vec2 color_range){
+vec4 get_color(sampler1D color, vec2 uv, vec2 color_range, Nothing matcap){
     float value = (uv.y - color_range.x) / (color_range.y - color_range.x);
     return texture(color, value);
 }
+
+vec4 matcap_color(sampler2D matcap){
+    vec2 muv = o_normal.xy * 0.5 + vec2(0.5, 0.5);
+    return texture2D(matcap, vec2(1.0-muv.y, muv.x));
+}
+vec4 get_color(Nothing image, vec2 uv, Nothing color_range, sampler2D matcap){
+    return matcap_color(matcap);
+}
+vec4 get_color(sampler2D color, vec2 uv, Nothing color_range, sampler2D matcap){
+    return matcap_color(matcap);
+}
+vec4 get_color(sampler1D color, vec2 uv, vec2 color_range, sampler2D matcap){
+    return matcap_color(matcap);
+}
+
+
+
 
 uniform bool fetch_pixel;
 uniform vec2 uv_scale;
@@ -68,13 +86,14 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
 
 void write2framebuffer(vec4 color, uvec2 id);
 
+
 void main(){
     vec4 color;
     // Should this be a mustache replace?
     if (fetch_pixel){
         color = get_pattern_color(image);
     }else{
-        color = get_color(image, o_uv, color_range);
+        color = get_color(image, o_uv, color_range, matcap);
     }
     {{light_calc}}
     write2framebuffer(color, o_id);

--- a/src/GLVisualize/visualize/mesh.jl
+++ b/src/GLVisualize/visualize/mesh.jl
@@ -6,6 +6,7 @@ function _default(mesh::TOrSignal{M}, s::Style, data::Dict) where M <: GeometryB
         vertex_color = Vec4f0(0)
         texturecoordinates = Vec2f0(0)
         image = nothing => Texture
+        matcap = nothing => Texture
         fetch_pixel = false
         uv_scale = Vec2f0(1)
         shader = GLVisualizeShader(

--- a/src/GLVisualize/visualize/particles.jl
+++ b/src/GLVisualize/visualize/particles.jl
@@ -97,6 +97,7 @@ function meshparticle(p, s, data)
             nothing
         end => to_meshcolor
         vertex_color = Vec4f0(1)
+        matcap = nothing => Texture
         fetch_pixel = false
         uv_scale = Vec2f0(1)
 

--- a/src/GLVisualize/visualize/surface.jl
+++ b/src/GLVisualize/visualize/surface.jl
@@ -84,6 +84,7 @@ function surface(main, s::Style{:surface}, data::Dict)
         color_map = nothing => Texture
         color_norm = nothing
         fetch_pixel = false
+        matcap = nothing => Texture
         uv_scale = Vec2f0(1)
         instances = const_lift(x->(size(x,1)-1) * (size(x,2)-1), main) => "number of planes used to render the surface"
         shader = GLVisualizeShader(


### PR DESCRIPTION
I learned about [matcaps](https://github.com/nidorx/matcaps) yesterday and they're pretty easy to add on a basic level. So here's an implementation for it. Should technically be used with `shading = false` or `ambient=Vec3f0(1), diffuse=Vec3f0(0), specular=Vec3f0(0)` but it doesn't make too much of a difference.

`mesh(m, matcap=image)`

![Screenshot from 2020-09-06 11-32-54](https://user-images.githubusercontent.com/10947937/92323683-0bcde100-f03b-11ea-957a-1ecfd2132c3f.png)
