### PR TITLE
Fix for mouse_selection / pick being unable to return plot indices > 65535

### DIFF
--- a/src/glwindow.jl
+++ b/src/glwindow.jl
@@ -32,7 +32,7 @@ mutable struct GLFramebuffer
     id::NTuple{2, GLuint}
 
     color::Texture{RGBA{N0f8}, 2}
-    objectid::Texture{Vec{2, GLushort}, 2}
+    objectid::Texture{Vec{2, GLuint}, 2}
     depth::Texture{GLAbstraction.DepthStencil_24_8, 2}
     position::Texture{Vec4f0, 2}
     normal_occlusion::Texture{Vec4f0, 2}
@@ -159,7 +159,7 @@ function GLFramebuffer(fb_size::NTuple{2, Int})
     glBindFramebuffer(GL_FRAMEBUFFER, render_framebuffer)
 
     color_buffer = Texture(RGBA{N0f8}, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
-    objectid_buffer = Texture(Vec{2, GLushort}, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
+    objectid_buffer = Texture(Vec{2, GLuint}, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
     position_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
     normal_occlusion_buffer = Texture(Vec4f0, fb_size, minfilter = :nearest, x_repeat = :clamp_to_edge)
 

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -391,7 +391,7 @@ end
 
 function pick_native(screen::Screen, xy::Vec{2, Float64})
     isopen(screen) || return SelectionID{Int}(0, 0)
-    sid = Base.RefValue{SelectionID{UInt16}}()
+    sid = Base.RefValue{SelectionID{UInt32}}()
     window_size = widths(screen)
     fb = screen.framebuffer
     buff = fb.objectid
@@ -418,7 +418,7 @@ function pick_native(screen::Screen, xy::Vec{2, Float64}, range::Float64)
     x0, y0 = max.(1, floor.(Int, xy .- range))
     x1, y1 = min.([w, h], floor.(Int, xy .+ range))
     dx = x1 - x0; dy = y1 - y0
-    sid = Matrix{SelectionID{UInt16}}(undef, dx, dy)
+    sid = Matrix{SelectionID{UInt32}}(undef, dx, dy)
     glReadPixels(x0, y0, dx, dy, buff.format, buff.pixeltype, sid)
 
     min_dist = range^2 # squared distance
@@ -457,7 +457,7 @@ end
 function AbstractPlotting.pick(screen::Screen, rect::IRect2D)
     window_size = widths(screen)
     buff = screen.framebuffer.objectid
-    sid = zeros(SelectionID{UInt16}, widths(rect)...)
+    sid = zeros(SelectionID{UInt32}, widths(rect)...)
     glReadBuffer(GL_COLOR_ATTACHMENT1)
     x, y = minimum(rect)
     rw, rh = widths(rect)

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -426,7 +426,7 @@ function pick_native(screen::Screen, xy::Vec{2, Float64}, range::Float64)
     x, y =  xy .+ 1 .- Vec2f0(x0, y0)
     for i in 1:dx, j in 1:dy
         d = (x-i)^2 + (y-j)^2
-        if (d < min_dist) && (sid[i, j][2] < 0xffff)
+        if (d < min_dist) && (sid[i, j][2] < 0x3f800000)
             min_dist = d
             id = convert(SelectionID{Int}, sid[i, j])
         end


### PR DESCRIPTION
This is a proposed fix for JuliaPlots/Makie.jl#703.

Can someone more experienced review the code and check that the fix doesn't break anything?

In particular, I am not too sure about the max value at screen.jl:429, for which I used 0x3f800000. Previously, it was 0xffff, i.e. 65535, the max value of the `UInt16` type. However, with this patch, the underlying type is `GLuint == UInt32` for which the max value is 0xffffffff and is much larger than 0x3f800000. Yet, 0x3f800000 appears empirically to be the max value returned by `glReadPixels` when there is no plot object at `xy`, which is why I used that here. I don't know where to check if that is the actual max value returned by `glReadPixels` under any circumstances.
