### PR TITLE
Fix for pick(::Screen, ::IRect2D) always throwing an error

### DIFF
--- a/src/screen.jl
+++ b/src/screen.jl
@@ -426,7 +426,7 @@ function pick_native(screen::Screen, xy::Vec{2, Float64}, range::Float64)
     x, y =  xy .+ 1 .- Vec2f0(x0, y0)
     for i in 1:dx, j in 1:dy
         d = (x-i)^2 + (y-j)^2
-        if (d < min_dist) && (sid[i, j][2] < 0xffff)
+        if (d < min_dist) && (sid[i, j][2] < 0x3f800000)
             min_dist = d
             id = convert(SelectionID{Int}, sid[i, j])
         end
@@ -466,7 +466,7 @@ function AbstractPlotting.pick(screen::Screen, rect::IRect2D)
     sid = zeros(SelectionID{UInt16}, widths(rect)...)
     if x > 0 && y > 0 && x <= w && y <= h
         glReadPixels(x, y, rw, rh, buff.format, buff.pixeltype, sid)
-        sid = filter(x -> x.id < 0xffff,sid)
+        sid = filter(x -> x.id < 0x3f800000,sid)
         return map(unique(vec(SelectionID{Int}.(sid)))) do sid
             (screen.cache2plot[sid.id], sid.index)
         end

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -456,12 +456,14 @@ end
 
 function AbstractPlotting.pick(screen::Screen, rect::IRect2D)
     window_size = widths(screen)
-    buff = screen.framebuffer.objectid
-    sid = zeros(SelectionID{UInt16}, widths(rect)...)
+    fb = screen.framebuffer
+    buff = fb.objectid
+    glBindFramebuffer(GL_FRAMEBUFFER, fb.id[1])
     glReadBuffer(GL_COLOR_ATTACHMENT1)
     x, y = minimum(rect)
     rw, rh = widths(rect)
     w, h = window_size
+    sid = zeros(SelectionID{UInt16}, widths(rect)...)
     if x > 0 && y > 0 && x <= w && y <= h
         glReadPixels(x, y, rw, rh, buff.format, buff.pixeltype, sid)
         return map(unique(vec(SelectionID{Int}.(sid)))) do sid

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -466,6 +466,7 @@ function AbstractPlotting.pick(screen::Screen, rect::IRect2D)
     sid = zeros(SelectionID{UInt16}, widths(rect)...)
     if x > 0 && y > 0 && x <= w && y <= h
         glReadPixels(x, y, rw, rh, buff.format, buff.pixeltype, sid)
+        sid = filter(x -> x.id < 0xffff,sid)
         return map(unique(vec(SelectionID{Int}.(sid)))) do sid
             (screen.cache2plot[sid.id], sid.index)
         end


### PR DESCRIPTION
This is a proposed fix for JuliaPlots/Makie.jl#704

There were actually two problems in `pick(screen::Screen, rect::IRect2D)`

Firstly it appears that `pick(screen::Screen, rect::IRect2D)` was missing the following two lines that appear in other `pick` / `pick_native` functions in screen.jl.
```julia
    fb = screen.framebuffer
    glBindFramebuffer(GL_FRAMEBUFFER, fb.id[1])
```

Secondly, with those added, the pick function works but only if all points within the `rect` are actually on a plot object. Otherwise, the following error is thrown
```julia
ERROR: KeyError: key 65535 not found
Stacktrace:
 [1] getindex at ./dict.jl:467 [inlined]
 [2] #170 at /home/.../.julia/dev/GLMakie/src/screen.jl:471 [inlined]
 [3] iterate at ./generator.jl:47 [inlined]
 [4] _collect(::Array{GLMakie.SelectionID{Int64},1}, ::Base.Generator{Array{GLMakie.SelectionID{Int64},1},GLMakie.var"#170#171"{GLMakie.Screen}}, ::Base.EltypeUnknown, ::Base.HasShape{1}) at ./array.jl:699
 [5] collect_similar(::Array{GLMakie.SelectionID{Int64},1}, ::Base.Generator{Array{GLMakie.SelectionID{Int64},1},GLMakie.var"#170#171"{GLMakie.Screen}}) at ./array.jl:628
 [6] map(::Function, ::Array{GLMakie.SelectionID{Int64},1}) at ./abstractarray.jl:2162
 [7] pick(::GLMakie.Screen, ::GeometryBasics.HyperRectangle{2,Int64}) at /home/.../.julia/dev/GLMakie/src/screen.jl:470
 [8] top-level scope at REPL[21]:1
 [9] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1088
```
65535 is the code returned in the `sid` variable to indicate that there is no plot object at the given coordinates. Those values must therefore be filtered out to get a list of the plot objects in the rect.

IMPORTANT: This PR conflicts with JuliaPlots/GLMakie.jl#126. If the latter is merged first then this PR needs to modified as the 65535 code should be replaced with 0x3f800000. 