### PR TITLE
Added additive blending shader

### DIFF
--- a/src/GLVisualize/assets/shader/volume.frag
+++ b/src/GLVisualize/assets/shader/volume.frag
@@ -146,8 +146,20 @@ vec4 volume(vec3 front, vec3 dir)
     return vec4(Lo, 1-T);
 }
 
+vec4 additivergba(vec3 front, vec3 dir)
+{
+    vec3 pos = front;
+    vec4 integrated_color = vec4(0., 0., 0., 0.);
+    int i = 0;
+    for (i; i < num_samples ; ++i) {
+        vec4 density = texture(volumedata, pos);
+        integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - density);
+        pos += dir;
+    }
+    return integrated_color;
+}
 
-vec4 volumergba(vec3 front, vec3 dir)
+vec4 absorptionrgba(vec3 front, vec3 dir)
 {
     vec3  pos = front;
     float T = 1.0;
@@ -296,6 +308,8 @@ void main()
     vec3 step_in_dir = (back_position - start) / num_samples;
 
     float steps = 0.1;
+    // the algorithm numbers correspond to the order in the
+    // RaymarchAlgorithm enum defined in AbstractPlotting types.jl 
     if(algorithm == 0)
         color = isosurface(start, step_in_dir);
     else if(algorithm == 1)
@@ -303,8 +317,10 @@ void main()
     else if(algorithm == 2)
         color = mip(start, step_in_dir);
     else if(algorithm == 3)
-        color = volumergba(start, step_in_dir);
+        color = absorptionrgba(start, step_in_dir);
     else if(algorithm == 4)
+        color = additivergba(start, step_in_dir);
+    else if(algorithm == 5)
         color = volumeindexedrgba(start, step_in_dir);
     else
         color = contours(start, step_in_dir);

--- a/src/GLVisualize/visualize/image_like.jl
+++ b/src/GLVisualize/visualize/image_like.jl
@@ -117,7 +117,7 @@ function _default(main::VolumeTypes{T}, s::Style, data::Dict) where T <: RGBA
         # These don't do anything but are needed for type specification in the frag shader
         color_map = nothing => Texture
         color_norm = nothing
-        color = color_map == nothing ? default(RGBA, s) : nothing
+        color = color_map === nothing ? default(RGBA, s) : nothing
 
         algorithm = AbsorptionRGBA
         shader = GLVisualizeShader("fragment_output.frag", "util.vert", "volume.vert", "volume.frag")


### PR DESCRIPTION
Additive blending shader for volumes, goes together with JuliaPlots/AbstractPlotting.jl#517

Example:
<img width="481" alt="additiveblending" src="https://user-images.githubusercontent.com/3041236/94806113-c01a1780-03ed-11eb-88ab-20e53000369a.png">

