### PR TITLE
add invert_normals to surface

### DIFF
--- a/src/GLVisualize/visualize/surface.jl
+++ b/src/GLVisualize/visualize/surface.jl
@@ -33,12 +33,13 @@ _extrema(x::FRect3D) = Vec2f0(minimum(x)[3], maximum(x)[3])
 nothing_or_vec(x) = x
 nothing_or_vec(x::Array) = vec(x)
 
-function normal_calc(x::Bool)
+function normal_calc(x::Bool, invert_normals::Bool = false)
+    i = invert_normals ? "-" : ""
     if x
-        "getnormal(position, position_x, position_y, position_z, o_uv);"
+        "$(i)getnormal(position, position_x, position_y, position_z, o_uv);"
         # "getnormal_fast(position_z, ind2sub(dims, index1D));"
     else
-        "vec3(0, 0, 1);"
+        "vec3(0, 0, $(i)1);"
     end
 end
 
@@ -78,6 +79,7 @@ function surface(main, s::Style{:surface}, data::Dict)
         distancefield = nothing => Texture
         shading = true
         normal = shading
+        invert_normals = false
     end
     @gen_defaults! data begin
         color = nothing => Texture
@@ -91,7 +93,7 @@ function surface(main, s::Style{:surface}, data::Dict)
             to_value(wireframe) ? "distance_shape.frag" : "standard.frag",
             view = Dict(
                 "position_calc" => position_calc(position, position_x, position_y, position_z, Texture),
-                "normal_calc" => normal_calc(normal),
+                "normal_calc" => normal_calc(normal, to_value(invert_normals)),
                 "light_calc" => light_calc(shading),
             )
         )


### PR DESCRIPTION
The "inside" or underside of a `surface` plot gets darkened a lot by ssao and isn't affected by shading, because `normals` are restricted to point one way - towards the "outside" or upside of the surface. To fix this, we essentially need to render to surfaces, one with normals pointing outside and one with normals pointing inside. This pr introduces `invert_normals::Bool` to do just that.

```julia
xs = range(-2pi, 2pi, length=51)
ys = range(-2pi, 2pi, length=51)
zs1 = sin.(xs) * cos.(ys)'
zs3 = cos.(xs) * sin.(ys)' .+ 1.2

# Old - see first image
s = Scene(SSAO=(blur=2, bias=0.05, radius=5.0))
surface!(xs, ys, zs1, ssao=true)
surface!(xs, ys, zs3, ssao=true)

# New - adding this gives the second image
surface!(xs, ys, zs3 .- 1e-3, ssao=true, invert_normals = true)
surface!(xs, ys, zs1 .- 1e-3, ssao=true, invert_normals = true)
```

![Screenshot from 2020-10-03 16-32-43](https://user-images.githubusercontent.com/10947937/94994554-9f41f580-0598-11eb-9e22-e227d7436491.png)
![Screenshot from 2020-10-03 16-32-59](https://user-images.githubusercontent.com/10947937/94994558-a10bb900-0598-11eb-956a-5618ad0d54bc.png)