### PR TITLE
Tests for PR #126,#127

### DIFF
--- a/test/glmakie_tests.jl
+++ b/test/glmakie_tests.jl
@@ -87,5 +87,40 @@
         scene
     end
 
+    @cell "Pick a plot element or plot elements inside a rectangle" [pick] begin
+        using Makie,GLMakie
+        using AbstractPlotting:project,transformationmatrix
+        using StaticArrays
+
+        # this function should probably be included in AbstractPlotting
+        function AbstractPlotting.project(scene::Scene,point::T) where T<:StaticVector
+            cam = scene.camera
+            project(cam.projection[]*cam.view[]*transformationmatrix(scene)[] , Vec2(scene.resolution[]), point)
+        end
+        
+        N = 100000
+        scene = scatter(1:N,1:N)
+        xlims!((99990,100000))
+        ylims!((99990,100000))
+        display(scene)
+        
+        # test for pick a single data point (with idx > 65535)
+        plot,idx = pick(scene,project(scene,Point((100000.,100000.))))
+        @assert idx == 100000
+        
+        # test for pick a rectangle of data points (also with some indices > 65535)
+        rect = FRect2D(99990.5,99990.5,8,8)
+        origin_px = project(scene,Point(origin(rect)))
+        tip_px    = project(scene,Point(origin(rect) .+ widths(rect)))
+        rect_px = IRect2D(round.(origin_px), round.(tip_px .- origin_px))
+        plot_idx = pick(AbstractPlotting.getscreen(scene),rect_px) #! there is no pick(::Scene,::IRect2D)
+        
+        # objects returned in plot_idx should be either grid lines (i.e. LineSegments) or Scatter points
+        @assert all([typeof(pi[1]) <: Union{LineSegments,Scatter} for pi in plot_idx])
+        # scatter points should have indices equal to those in 99991:99998
+        scatter_plot_idx = filter(pi -> typeof(pi[1]) <: Scatter, plot_idx)
+        @assert Set([pi[2] for pi in scatter_plot_idx]) == Set(99991:99998)
+    end
+
 
 end

--- a/test/glmakie_tests.jl
+++ b/test/glmakie_tests.jl
@@ -91,6 +91,7 @@
         using Makie,GLMakie
         using AbstractPlotting:project,transformationmatrix
         using StaticArrays
+        using GeometryBasics
 
         # this function should probably be included in AbstractPlotting
         function AbstractPlotting.project(scene::Scene,point::T) where T<:StaticVector
@@ -105,7 +106,10 @@
         display(scene)
         
         # test for pick a single data point (with idx > 65535)
-        plot,idx = pick(scene,project(scene,Point((100000.,100000.))))
+        idx = 0
+        while idx == 0
+            plot,idx = pick(scene,project(scene,Point((100000.,100000.))))
+        end
         @assert idx == 100000
         
         # test for pick a rectangle of data points (also with some indices > 65535)


### PR DESCRIPTION
These are WIP tests for PR #126 #127.

There are a few issues.
- the function `AbstractPlotting.project(scene::Scene,point::T) where T<:StaticVector` should probably go in `AbstractPlotting`. (PR JuliaPlots/AbstractPlotting.jl#521)
- similarly, there is no `pick(::Scene,::IRect2D)` in `AbstractPlotting`, hence I used `pick(getscreen(scene),...)`. Perhaps `pick(::Scene,::IRect2D)`  should be added to `AbstractPlotting` too? Although perhaps it would make sense to use an `FRect2D` instead?
- the `while idx==0` loop is just to wait for `display(scene)` to finish its job. There must be a better way (that doesn't risk getting into an infinite loop). `GLMakie.pick_native` doesn't return the right object until `display(scene)` is done.
- currently, the tests work when I run the code manually in the REPL but they **don't work** when run with the `runtests` script. I am not sure why exactly. Maybe something to do with the scenes not actually being rendered when running the tests?

Disclaimer: these are the firsts tests I ever wrote for a Julia package :) Thanks for letting me know of any issues with those.