### PR TITLE
Apple resolution fix

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -177,10 +177,11 @@ function disconnect!(window::GLFW.Window, ::typeof(unicode_input))
 end
 
 # TODO memoise? Or to bug ridden for the small performance gain?
-function retina_scaling_factor(w, fb)
-    (w[1] == 0 || w[2] == 0) && return (1.0, 1.0)
-    fb ./ w
-end
+# So long as retina scaling is disabled memoise not needed
+# function retina_scaling_factor(w, fb)
+#     (w[1] == 0 || w[2] == 0) && return (1.0, 1.0)
+#     fb ./ w
+# end
 
 function framebuffer_size(window::GLFW.Window)
     wh = GLFW.GetFramebufferSize(window)
@@ -190,15 +191,18 @@ function window_size(window::GLFW.Window)
     wh = GLFW.GetWindowSize(window)
     (wh.width, wh.height)
 end
-function retina_scaling_factor(window::GLFW.Window)
-    w, fb = window_size(window), framebuffer_size(window)
-    retina_scaling_factor(w, fb)
-end
+# function retina_scaling_factor(window::GLFW.Window)
+#     w, fb = window_size(window), framebuffer_size(window)
+#     retina_scaling_factor(w, fb)
+# end
 
 function correct_mouse(window::GLFW.Window, w, h)
     ws, fb = window_size(window), framebuffer_size(window)
-    s = retina_scaling_factor(ws, fb)
-    (w * s[1], fb[2] - (h * s[2]))
+    
+    #Not Needed while Retina is disable
+    #s = retina_scaling_factor(ws, fb)
+    #(w * s[1], fb[2] - (h * s[2]))
+    (w , fb[2] - (h))
 end
 
 """

--- a/src/glwindow.jl
+++ b/src/glwindow.jl
@@ -246,7 +246,12 @@ function MonitorProperties(monitor::GLFW.Monitor)
     position = Vec{2, Int}(GLFW.GetMonitorPos(monitor)...)
     physicalsize = Vec{2, Int}(GLFW.GetMonitorPhysicalSize(monitor)...)
     videomode = GLFW.GetVideoMode(monitor)
-    sfactor = Sys.isapple() ? 2.0 : 1.0
+    
+    #Retina style full Framebuffer is diabled now but may be reintroduced latter
+    #Even then this logic will need to be more complicated to deal with non Retina displays
+    # sfactor = Sys.isapple() ? 2.0 : 1.0
+    sfactor = 1.0
+
     dpi = Vec(videomode.width * 25.4, videomode.height * 25.4) * sfactor ./ Vec{2, Float64}(physicalsize)
     videomode_supported = GLFW.GetVideoModes(monitor)
 

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -294,7 +294,9 @@ function Screen(;
         empty!(gl_screens)
     end
     # Somehow this constant isn't wrapped by glfw
+    # TODO move these hint declorations to GLFW.jl
     GLFW_FOCUS_ON_SHOW = 0x0002000C
+    GLFW_COCOA_RETINA_FRAMEBUFFER=0x00023001
     windowhints = [
         (GLFW.SAMPLES,      0),
         (GLFW.DEPTH_BITS,   0),
@@ -311,10 +313,11 @@ function Screen(;
         (GLFW_FOCUS_ON_SHOW, WINDOW_CONFIG.focus_on_show[]),
         (GLFW.DECORATED, WINDOW_CONFIG.decorated[]),
         (GLFW.FLOATING, WINDOW_CONFIG.float[]),
+        (GLFW_COCOA_RETINA_FRAMEBUFFER, false), #This is needed otherwise on apple system will be drawing 4x or 9x the needed pixels
     ]
 
     window = GLFW.Window(
-        name = title, resolution = (10, 10), # 10, because smaller sizes seem to error on some platforms
+        name = title, resolution = resolution, 
         windowhints = windowhints,
         visible = false,
         focus = false,

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -84,8 +84,10 @@ end
 function Base.resize!(window::GLFW.Window, resolution...)
     if isopen(window)
         oldsize = windowsize(window)
-        retina_scale = retina_scaling_factor(window)
-        w, h = resolution ./ retina_scale
+        #TODO Retina style scaling should eventually be reenable but not by default
+        #   Work would need to be done to ensure it worked in all cases
+        #retina_scale = retina_scaling_factor(window)
+        w, h = resolution #./ retina_scale
         if oldsize == (w, h)
             return
         end


### PR DESCRIPTION
This makes the resolution KW work properly on OSX.   It effectively disables the expanded Retina framebuffer and then gets rid of a lot of the "retina scaling".  That may cause issue with high DPI screens on non-apple platforms, but as far as I could tell I don't think that would have been working.

This does dramatically improve performance on my machine, as I think that on a retina display it was actually rendering at 2x the native resolution to start with.   
My machine went from unusable with a large window to being very ussable.

Allong with: https://github.com/JuliaPlots/AbstractPlotting.jl/pull/563
this should close https://github.com/JuliaPlots/Makie.jl/issues/766