### PR TITLE
attempt at scaling linestyle patterns by linewidth

### DIFF
--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -215,7 +215,13 @@ function draw_atomic(screen::GLScreen, scene::Scene, @nospecialize(x::Lines))
     robj = cached_robj!(screen, scene, x) do gl_attributes
         linestyle = pop!(gl_attributes, :linestyle)
         data = Dict{Symbol, Any}(gl_attributes)
-        data[:pattern] = to_value(linestyle)
+        ls = to_value(linestyle)
+        if isnothing(ls)
+            data[:pattern] = ls
+        else
+            linewidth = gl_attributes[:thickness]
+            data[:pattern] = ls .* (to_value(linewidth) * 0.25)
+        end
         positions = handle_view(x[1], data)
         positions = apply_transform(transform_func_obs(x), positions)
         handle_intensities!(data)
@@ -227,7 +233,13 @@ function draw_atomic(screen::GLScreen, scene::Scene, @nospecialize(x::LineSegmen
     robj = cached_robj!(screen, scene, x) do gl_attributes
         linestyle = pop!(gl_attributes, :linestyle)
         data = Dict{Symbol, Any}(gl_attributes)
-        data[:pattern] = to_value(linestyle)
+        ls = to_value(linestyle)
+        if isnothing(ls)
+            data[:pattern] = ls
+        else
+            linewidth = gl_attributes[:thickness]
+            data[:pattern] = ls .* (to_value(linewidth) * 0.25)
+        end
         positions = handle_view(x.converted[1], data)
         positions = apply_transform(transform_func_obs(x), positions)
         if haskey(data, :color) && data[:color][] isa AbstractVector{<: Number}


### PR DESCRIPTION
Companion to https://github.com/JuliaPlots/AbstractPlotting.jl/pull/593 to fix https://github.com/JuliaPlots/Makie.jl/issues/807

I will need your help here, @SimonDanisch. What is the unit of linewidth? And what is the unit of the linestyle patterns? I need this to figure out the right scaling. I now scaled by linewidth/4 and it doesn't look too bad.

This is what I am getting now.

![image](https://user-images.githubusercontent.com/6280307/103915909-180e9b80-510c-11eb-9bd8-64af383e9019.png)

EDIT: The sentence didn't make sense, sorry.