### PR TITLE
@print_error in mouseposition events

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -208,7 +208,7 @@ function mouse_position(scene::Scene, screen::Screen)
         x, y = GLFW.GetCursorPos(window)
         pos = correct_mouse(window, x, y)
         if pos != e.mouseposition[]
-            e.mouseposition[] = pos
+            @print_error e.mouseposition[] = pos
         end
         return
     end


### PR DESCRIPTION
Allows recovery from errors in mouse position events, as in other events type, e.g. when dragging the slider here:
```
fig = Figure()
fig[1,1] = sl = Slider(fig)
on(sl.value) do v
    v == 5 && error()
end
display(fig)
```