### PR TITLE
Remove FileIO cruft from GLAbstraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.1.28"
+version = "0.1.29"
 
 [deps]
 AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"

--- a/src/GLAbstraction/GLAbstraction.jl
+++ b/src/GLAbstraction/GLAbstraction.jl
@@ -6,15 +6,12 @@ using ModernGL
 using AbstractPlotting
 using FixedPointNumbers
 using ColorTypes
-using FileIO
 using ..GLMakie.GLFW
 using Printf
 using LinearAlgebra
 using Observables
 using ShaderAbstractions
 using ShaderAbstractions: current_context, is_context_active, context_alive
-
-import FileIO: load, save
 
 import FixedPointNumbers: N0f8, N0f16, N0f8, Normed
 

--- a/src/GLAbstraction/GLShader.jl
+++ b/src/GLAbstraction/GLShader.jl
@@ -61,13 +61,12 @@ function createprogram()
 end
 
 shadertype(s::Shader) = s.typ
-
 function shadertype(ext::AbstractString)
     ext == ".comp" && return GL_COMPUTE_SHADER
     ext == ".vert" && return GL_VERTEX_SHADER
     ext == ".frag" && return GL_FRAGMENT_SHADER
     ext == ".geom" && return GL_GEOMETRY_SHADER
-    error("$ext not a valid extension for $f")
+    error("$ext not a valid shader extension")
 end
 
 function uniformlocations(nametypedict::Dict{Symbol, GLenum}, program)

--- a/src/display.jl
+++ b/src/display.jl
@@ -42,12 +42,23 @@ raw_io(io::IOContext) = raw_io(io.io)
 
 function AbstractPlotting.backend_show(::GLBackend, io::IO, m::MIME"image/png", scene::Scene)
     img, screen = scene2image(scene)
-    FileIO.save(FileIO.Stream{FileIO.format"PNG"}(raw_io(io)), img)
+    # TODO: when FileIO 1.6 is the minimum required version, delete the conditional
+    if isdefined(FileIO, :action)   # FileIO 1.6+
+        # keep this one
+        FileIO.save(FileIO.Stream{FileIO.format"PNG"}(raw_io(io)), img)
+    else
+        # delete this one
+        FileIO.save(FileIO.Stream(FileIO.format"PNG", raw_io(io)), img)
+    end
     return screen
 end
 
 function AbstractPlotting.backend_show(::GLBackend, io::IO, m::MIME"image/jpeg", scene::Scene)
     img, screen = scene2image(scene)
-    FileIO.save(FileIO.Stream{FileIO.format"JPEG"}(raw_io(io)), img)
+    if isdefined(FileIO, :action)   # FileIO 1.6+
+        FileIO.save(FileIO.Stream{FileIO.format"JPEG"}(raw_io(io)), img)
+    else
+        FileIO.save(FileIO.Stream(FileIO.format"JPEG", raw_io(io)), img)
+    end
     return screen
 end


### PR DESCRIPTION
FileIO 1.6 inadvertently broke GLMakie.  The reason is interesting, in https://github.com/JuliaIO/FileIO.jl/pull/295#issuecomment-788029573 I noted that this line:

https://github.com/JuliaIO/FileIO.jl/blob/71bdffe1f3933aa51e7d7c42f50b90589e52d7f4/src/registry.jl#L139

registered a format with no obvious corresponding package. Thinking it was without effect, I deleted it.

Well, there is a GLAbstraction that's a sub-module of GLMakie. BUT that turns out to be irrelevant. The reason is that the true purpose of that line was to define a `DataFormat` for shaders, and it was used in a single place within GLMakie, a call to `query`. Other than extracting the format, there was no other actual use of FileIO in GLAbstraction: FileIO never called back to the `load` and `save` methods that were defined (and inappropriately extending `FileIO.load` and `FileIO.save`).

Since there are no magic bytes, that `query` was literally just `splitext`. Let's just do that instead.

Should you ever need to register GLAbstraction, now you can do it like this:

```julia
function __init__()
    # For shadertype
    if isdefined(FileIO, :action)
        add_format(format"GLSLShader", (), [".frag", ".vert", ".geom", ".comp"], [GLAbstraction])
    end
end
```
