### PR TITLE
Add pickable attribute

### DIFF
--- a/assets/shader/fragment_output.frag
+++ b/assets/shader/fragment_output.frag
@@ -8,12 +8,16 @@ layout(location=1) out uvec2 fragment_groupid;
 in vec4 o_view_pos;
 in vec3 o_normal;
 
+uniform bool pickable;
+
 void write2framebuffer(vec4 color, uvec2 id){
     if(color.a <= 0.0)
         discard;
     // For FXAA & SSAO
     fragment_color = color;
+    
     // For plot/sprite picking
-    fragment_groupid = id;
+    if(pickable)
+        fragment_groupid = id;
     {{buffer_writes}}
 }

--- a/src/GLVisualize/visualize_interface.jl
+++ b/src/GLVisualize/visualize_interface.jl
@@ -164,6 +164,7 @@ function visualize(@nospecialize(main), @nospecialize(s), @nospecialize(data))
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f0(I)
+        pickable = true
     end
     return assemble_shader(data)
 end

--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -314,7 +314,8 @@ function draw_atomic(screen::GLScreen, scene::Scene, x::Text)
             robj[:projectionview] = scene.camera.pixel_space
         end
         robj[:model] = x.model
-
+        robj[:pickable] = get(x, :pickable, true)
+        
         return robj
     end
     return robj


### PR DESCRIPTION
This pr adds a `pickable::Bool` attribute that allows you to disable point picking for a plot. 

My aim with this is to make `pick(..., range)` more useful. For example consider a line plot on an `Axis`. Currently there is a background mesh in `Axis` which will be picked whenever you're not exactly on the line. With this pr you can make the background not pickable, meaning that `pick(..., range)` has a chance to select the line as the next closest object.

In the context of https://github.com/JuliaPlots/AbstractPlotting.jl/pull/677 this will also be helpful to avoid picking the information that's being displayed. (Probably necessary to avoid flickering if we display near the cursor.)