### PR TITLE
always forward model matrix in Text

### DIFF
--- a/src/drawing_primitives.jl
+++ b/src/drawing_primitives.jl
@@ -312,9 +312,8 @@ function draw_atomic(screen::GLScreen, scene::Scene, x::Text)
             robj[:view] = Observable(Mat4f0(I))
             robj[:projection] = scene.camera.pixel_space
             robj[:projectionview] = scene.camera.pixel_space
-        else
-            robj[:model] = x.model
         end
+        robj[:model] = x.model
 
         return robj
     end


### PR DESCRIPTION
This allows things like `translate!()` to work (again).

Here's an example that hides the text on master but shows it with this change
```julia
fig = Figure()
t = text!(fig.scene, "Test", position = Point2f0(0, 150), show_axis=false)
m = mesh!(fig.scene, Rect2D(Point2f0(0, 140), Vec2f0(50, 40)), show_axis=false, color=:orange)
translate!(m, Vec3f0(0,0,1))
translate!(t, Vec3f0(0,0,2))
```

I sort of need this for https://github.com/JuliaPlots/AbstractPlotting.jl/pull/677 to have a background for text while keeping everything in the foreground.