### PR TITLE
Change ranged pick to return all plots sorted by distance

### DIFF
--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -40,13 +40,12 @@ end
         origin_px = project_sp(ax.scene, Point(origin(rect)))
         tip_px = project_sp(ax.scene, Point(origin(rect) .+ widths(rect)))
         rect_px = IRect2D(round.(origin_px), round.(tip_px .- origin_px))
-        #! there is no pick(::Scene,::IRect2D)
-        plot_idx = pick(screen, rect_px)
+        picks = unique(pick(ax.scene, rect_px))
 
         # objects returned in plot_idx should be either grid lines (i.e. LineSegments) or Scatter points
-        @test all(pi-> pi[1] isa Union{LineSegments,Scatter, AbstractPlotting.Mesh}, plot_idx)
+        @test all(pi-> pi[1] isa Union{LineSegments,Scatter, AbstractPlotting.Mesh}, picks)
         # scatter points should have indices equal to those in 99991:99998
-        scatter_plot_idx = filter(pi -> pi[1] isa Scatter, plot_idx)
+        scatter_plot_idx = filter(pi -> pi[1] isa Scatter, picks)
         @test Set(last.(scatter_plot_idx)) == Set(99991:99998)
     end
 end


### PR DESCRIPTION
As an alternative (or addition) to #174.

To ignore a scatter plot

... with #174 :
```julia
fig, ax, p = scatter(rand(Point2f0, 10), pickable = false)
on(events(fig.scene).mouseposition) do mp
    plt, idx = pick(fig.scene, mp, 30)
    println(typeof(plt), " @ ", idx)
end
```

... with this :
```julia
fig, ax, p = scatter(rand(Point2f0, 10), e)
on(events(fig.scene).mouseposition) do mp
    for (plt, idx) in pick(fig.scene, mp, 30)
        if plt != p
            println(typeof(plt), " @ ", idx)
            break
        end
    end
end
```

I personally prefer #174. It makes more sense to me to for a plot to be pickable or not, than for that to be decided in `pick`. It's also simpler to use, especially if you want to avoid picking plots from, for example, axis.  (For that you'd need to compare to `fig.scene.plots`)