### PR TITLE
fix light calc with backlight

### DIFF
--- a/assets/shader/standard.frag
+++ b/assets/shader/standard.frag
@@ -75,9 +75,9 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
     float spec_coeff = pow(max(dot(H, N), 0.0), shininess);
     if (diff_coeff <= 0.0 || isnan(spec_coeff))
         spec_coeff = 0.0;
+
     // final lighting model
     return vec3(
-        ambient * color +
         diffuse * diff_coeff * color +
         specular * spec_coeff
     );

--- a/src/GLVisualize/visualize/surface.jl
+++ b/src/GLVisualize/visualize/surface.jl
@@ -64,8 +64,8 @@ function light_calc(x::Bool)
         vec3 L      = normalize(o_lightdir);
         vec3 N      = normalize(o_normal);
         vec3 light1 = blinnphong(N, o_camdir, L, color.rgb);
-        color       = vec4(light1, color.a) + 
-            backlight * vec4(blinnphong(N, o_camdir, -L, color.rgb), color.a);
+        vec3 light2 = blinnphong(N, o_camdir, -L, color.rgb);
+        color       = vec4(ambient * color.rgb + light1 + backlight * light2, color.a);
         """
     else
         ""


### PR DESCRIPTION
The way `backlight` was implemented results in `ambient` being applied twice. This pr fixes that.

## With `backlight = 0f0`:
![Screenshot from 2021-04-10 20-25-48](https://user-images.githubusercontent.com/10947937/114280800-584b2600-9a3b-11eb-87c6-91aa8eb2578c.png)

## With `backlight = 1f0` on master:
![Screenshot from 2021-04-10 20-25-11](https://user-images.githubusercontent.com/10947937/114280821-6ac55f80-9a3b-11eb-8485-5e1d2f29a8d8.png)

## With `backlight = 1f0` after these changes:
![Screenshot from 2021-04-10 20-25-40](https://user-images.githubusercontent.com/10947937/114280834-79137b80-9a3b-11eb-9090-8e89d3dc6512.png)